### PR TITLE
Bootstrap improvements

### DIFF
--- a/Zinc-ObjC.xcodeproj/project.pbxproj
+++ b/Zinc-ObjC.xcodeproj/project.pbxproj
@@ -129,6 +129,8 @@
 		B3E743B915998B9F0098DB19 /* com.mindsnacks.demo1.cats.tar in Resources */ = {isa = PBXBuildFile; fileRef = B3E743B715998B9F0098DB19 /* com.mindsnacks.demo1.cats.tar */; };
 		B3EACD8614BD4907004D90EC /* ZincGarbageCollectTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B3EACD8414BD4905004D90EC /* ZincGarbageCollectTask.h */; };
 		B3EACD8714BD4907004D90EC /* ZincGarbageCollectTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */; };
+		B3F14A5D15BB840900F7E22E /* ZincTaskActions.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F14A5B15BB840900F7E22E /* ZincTaskActions.h */; };
+		B3F14A5E15BB840900F7E22E /* ZincTaskActions.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */; };
 		B3F8AF76148EFCDF00CB92B5 /* ZincRepo.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F8AF74148EFCDF00CB92B5 /* ZincRepo.h */; };
 		B3F8AF77148EFCDF00CB92B5 /* ZincRepo.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */; };
 		D00356D9153760220021627E /* ZincEvent+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D00356D8153760220021627E /* ZincEvent+Private.h */; };
@@ -297,6 +299,8 @@
 		B3E743B715998B9F0098DB19 /* com.mindsnacks.demo1.cats.tar */ = {isa = PBXFileReference; lastKnownFileType = archive.tar; path = com.mindsnacks.demo1.cats.tar; sourceTree = "<group>"; };
 		B3EACD8414BD4905004D90EC /* ZincGarbageCollectTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincGarbageCollectTask.h; sourceTree = "<group>"; };
 		B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincGarbageCollectTask.m; sourceTree = "<group>"; };
+		B3F14A5B15BB840900F7E22E /* ZincTaskActions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincTaskActions.h; sourceTree = "<group>"; };
+		B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincTaskActions.m; sourceTree = "<group>"; };
 		B3F76102158292B800B2C194 /* generate_manifest_from_local_file_list.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = generate_manifest_from_local_file_list.py; sourceTree = "<group>"; };
 		B3F8AF74148EFCDF00CB92B5 /* ZincRepo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincRepo.h; sourceTree = "<group>"; };
 		B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincRepo.m; sourceTree = "<group>"; };
@@ -585,6 +589,8 @@
 			children = (
 				B3215E2014BE5AF800FC7FA7 /* ZincTaskDescriptor.h */,
 				B3215E2114BE5AF800FC7FA7 /* ZincTaskDescriptor.m */,
+				B3F14A5B15BB840900F7E22E /* ZincTaskActions.h */,
+				B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */,
 				B327070C14BCC722004E3244 /* ZincTask.h */,
 				B327070D14BCC723004E3244 /* ZincTask.m */,
 				B327071014BCCB88004E3244 /* ZincSourceUpdateTask.h */,
@@ -758,6 +764,7 @@
 				D00356D9153760220021627E /* ZincEvent+Private.h in Headers */,
 				B396E3081590F56F00584F83 /* ZincBundleBootstrapTask.h in Headers */,
 				B396E30C1590FB8D00584F83 /* ZincBundleCloneTask.h in Headers */,
+				B3F14A5D15BB840900F7E22E /* ZincTaskActions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -963,6 +970,7 @@
 				B32EEB1214FEDCEE005F9917 /* ZincHTTPStreamOperation.m in Sources */,
 				B396E3091590F56F00584F83 /* ZincBundleBootstrapTask.m in Sources */,
 				B396E30D1590FB8D00584F83 /* ZincBundleCloneTask.m in Sources */,
+				B3F14A5E15BB840900F7E22E /* ZincTaskActions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Zinc/ZincBundleCloneTask.m
+++ b/Zinc/ZincBundleCloneTask.m
@@ -13,12 +13,18 @@
 #import "ZincEvent.h"
 #import "ZincRepo+Private.h"
 #import "ZincManifest.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincBundleCloneTask
 
 @synthesize fileManager = _fileManager;
 
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 - (void)dealloc
+
 {
     [_fileManager release];
     [super dealloc];

--- a/Zinc/ZincBundleDeleteTask.m
+++ b/Zinc/ZincBundleDeleteTask.m
@@ -12,8 +12,14 @@
 #import "ZincEvent.h"
 #import "ZincManifest.h"
 #import "ZincResource.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincBundleDeleteTask
+
++ (NSString *)action
+{
+    return ZincTaskActionDelete;
+}
 
 - (void)dealloc
 {

--- a/Zinc/ZincCatalogUpdateTask.m
+++ b/Zinc/ZincCatalogUpdateTask.m
@@ -13,8 +13,13 @@
 #import "ZincRepo+Private.h"
 #import "ZincEvent.h"
 #import "NSData+Zinc.h"
-
+#import "ZincTaskActions.h"
 @implementation ZincCatalogUpdateTask
+
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 
 - (id) initWithRepo:(ZincRepo*)repo resourceDescriptor:(NSURL*)resource input:(id)input
 {

--- a/Zinc/ZincDownloadTask.m
+++ b/Zinc/ZincDownloadTask.m
@@ -12,6 +12,7 @@
 #import "ZincEvent.h"
 #import "ZincHTTPURLConnectionOperation.h"
 #import "ZincHTTPStreamOperation.h"
+#import "ZincTaskActions.h"
 
 @interface ZincDownloadTask()
 @property (nonatomic, retain, readwrite) id context;
@@ -23,6 +24,11 @@
 @synthesize totalBytesToRead = _totalBytesToRead;
 
 @synthesize context = _context;
+
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 
 - (ZincHTTPRequestOperation *) queuedOperationForRequest:(NSURLRequest *)request outputStream:(NSOutputStream *)outputStream context:(id)context
 {

--- a/Zinc/ZincErrors.h
+++ b/Zinc/ZincErrors.h
@@ -23,10 +23,10 @@ enum
     ZINC_ERR_INVALID_FORMAT                       = 2002,
     ZINC_ERR_INVALID_REPO_FORMAT                  = 2101,
     ZINC_ERR_INVALID_MANIFEST_FORMAT              = 2102,
-
     
     ZINC_ERR_NO_SOURCES_FOR_CATALOG               = 3101,
-
     
+    ZINC_ERR_BOOTSTRAP_MANIFEST_NOT_FOUND         = 5101,
+
     ZINC_ERR_UNKNOWN                              = 99999,
 };

--- a/Zinc/ZincGarbageCollectTask.m
+++ b/Zinc/ZincGarbageCollectTask.m
@@ -12,8 +12,14 @@
 #import "ZincResource.h"
 #import "ZincManifest.h"
 #import "ZincEvent.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincGarbageCollectTask
+
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 
 - (void) main
 {

--- a/Zinc/ZincGlobals.h
+++ b/Zinc/ZincGlobals.h
@@ -25,6 +25,8 @@ enum  {
 extern NSString* const ZincFileFormatRaw;
 extern NSString* const ZincFileFormatGZ;
 
+extern NSString* const ZincDistributionLocal;
+
 #ifdef ZINC_DEBUG
     #define ZINC_DEBUG_LOG(fmt, ...) (NSLog(fmt, ##__VA_ARGS__));
 #else

--- a/Zinc/ZincGlobals.m
+++ b/Zinc/ZincGlobals.m
@@ -2,3 +2,4 @@
 
 NSString* const ZincFileFormatRaw = @"raw";
 NSString* const ZincFileFormatGZ = @"gz";
+NSString* const ZincDistributionLocal = @"local";

--- a/Zinc/ZincManifestDownloadTask.m
+++ b/Zinc/ZincManifestDownloadTask.m
@@ -19,6 +19,7 @@
 #import "ZincEvent.h"
 #import "ZincErrors.h"
 #import "ZincKSJSON.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincManifestDownloadTask
 

--- a/Zinc/ZincRepo+Private.h
+++ b/Zinc/ZincRepo+Private.h
@@ -36,8 +36,6 @@
 
 #pragma mark Bundles
 
-- (void) beginTrackingBundleWithId:(NSString *)bundleId distribution:(NSString *)distro localManifestPath:(NSString*)manifestPath;
-
 - (void) registerBundle:(NSURL*)bundleResource status:(ZincBundleState)status;
 - (void) deregisterBundle:(NSURL*)bundleResource;
 

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -70,7 +70,8 @@ extern NSString* const ZincRepoBundleCloneProgressKey;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro;
 - (void) stopTrackingBundleWithId:(NSString*)bundleId;
 
-- (BOOL) bootstrapBundleWithId:(NSString*)bundleId fromDir:(NSString*)path waitUntilDone:(BOOL)wait;
+- (BOOL) bootstrapBundleWithId:(NSString*)bundleId fromDir:(NSString*)dir error:(NSError**)outError;
+- (void) waitForAllBootstrapTasks;
 
 - (NSSet*) trackedBundleIds;
 

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -70,7 +70,7 @@ extern NSString* const ZincRepoBundleCloneProgressKey;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro;
 - (void) stopTrackingBundleWithId:(NSString*)bundleId;
 
-- (void) bootstrapBundleWithId:(NSString*)bundleId fromDir:(NSString*)path andTrack:(NSString*)distro waitUntilDone:(BOOL)wait;
+- (BOOL) bootstrapBundleWithId:(NSString*)bundleId fromDir:(NSString*)path waitUntilDone:(BOOL)wait;
 
 - (NSSet*) trackedBundleIds;
 

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -68,8 +68,9 @@ extern NSString* const ZincRepoBundleCloneProgressKey;
 #pragma mark Bundles
 
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro;
-- (void) beginTrackingBundleWithId:(NSString *)bundleId distribution:(NSString *)distro automaticallyBootstrapFromPath:(NSString*)dir;
 - (void) stopTrackingBundleWithId:(NSString*)bundleId;
+
+- (void) bootstrapBundleWithId:(NSString*)bundleId fromDir:(NSString*)path andTrack:(NSString*)distro waitUntilDone:(BOOL)wait;
 
 - (NSSet*) trackedBundleIds;
 

--- a/Zinc/ZincRepoIndexUpdateTask.m
+++ b/Zinc/ZincRepoIndexUpdateTask.m
@@ -13,8 +13,14 @@
 #import "ZincRepoIndex.h"
 #import "ZincEvent.h"
 #import "NSData+Zinc.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincRepoIndexUpdateTask
+
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 
 - (id) initWithRepo:(ZincRepo*)repo resourceDescriptor:(NSURL*)resource input:(id)input
 {

--- a/Zinc/ZincSourceUpdateTask.m
+++ b/Zinc/ZincSourceUpdateTask.m
@@ -17,9 +17,14 @@
 #import "ZincCatalogUpdateTask.h"
 #import "ZincResource.h"
 #import "ZincErrors.h"
+#import "ZincTaskActions.h"
 
 @implementation ZincSourceUpdateTask
 
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
 
 - (id) initWithRepo:(ZincRepo *)repo resourceDescriptor:(NSURL *)resource input:(id)input
 {

--- a/Zinc/ZincTask.m
+++ b/Zinc/ZincTask.m
@@ -95,6 +95,12 @@ static const NSString* kvo_SubtaskIsFinished = @"kvo_SubtaskIsFinished";
     return 0;
 }
 
++ (NSString *)action
+{
+    NSAssert(NO, @"subclasses must override");
+    return nil;
+}
+
 + (NSString*) taskMethod
 {
     return NSStringFromClass(self);
@@ -102,7 +108,7 @@ static const NSString* kvo_SubtaskIsFinished = @"kvo_SubtaskIsFinished";
 
 + (ZincTaskDescriptor*) taskDescriptorForResource:(NSURL*)resource
 {
-    return [ZincTaskDescriptor taskDescriptorWithResource:resource method:[self taskMethod]];
+    return [ZincTaskDescriptor taskDescriptorWithResource:resource action:[self action] method:[self taskMethod]];
 }
 
 - (ZincTaskDescriptor*) taskDescriptor

--- a/Zinc/ZincTaskActions.h
+++ b/Zinc/ZincTaskActions.h
@@ -1,0 +1,19 @@
+//
+//  ZincTaskActions.h
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 7/21/12.
+//  Copyright (c) 2012 MindSnacks. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const ZincTaskActionUpdate;
+extern NSString *const ZincTaskActionDelete;
+
+//extern NSString *const ZincTaskActionGarbageCollect;
+//extern NSString *const ZincTaskActionSourceUpdate;
+//extern NSString *const ZincTaskActionRepoIndexUpdate;
+//extern NSString *const ZincTaskActionRepoBundleClone;
+//extern NSString *const ZincTaskActionDownload;
+

--- a/Zinc/ZincTaskActions.h
+++ b/Zinc/ZincTaskActions.h
@@ -10,10 +10,3 @@
 
 extern NSString *const ZincTaskActionUpdate;
 extern NSString *const ZincTaskActionDelete;
-
-//extern NSString *const ZincTaskActionGarbageCollect;
-//extern NSString *const ZincTaskActionSourceUpdate;
-//extern NSString *const ZincTaskActionRepoIndexUpdate;
-//extern NSString *const ZincTaskActionRepoBundleClone;
-//extern NSString *const ZincTaskActionDownload;
-

--- a/Zinc/ZincTaskActions.m
+++ b/Zinc/ZincTaskActions.m
@@ -1,0 +1,18 @@
+//
+//  ZincTaskActions.m
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 7/21/12.
+//  Copyright (c) 2012 MindSnacks. All rights reserved.
+//
+
+#import "ZincTaskActions.h"
+
+NSString *const ZincTaskActionUpdate = @"UPDATE";
+NSString *const ZincTaskActionDelete = @"DELETE";
+
+//NSString *const ZincTaskActionGarbageCollect = @"GARBAGE-COLLECT";
+//NSString *const ZincTaskActionSourceUpdate = @"SOURCE-UPDATE";
+//NSString *const ZincTaskActionRepoIndexUpdate = @"
+//NSString *const ZincTaskActionRepoBundleClone;
+//NSString *const ZincTaskActionDownload;

--- a/Zinc/ZincTaskActions.m
+++ b/Zinc/ZincTaskActions.m
@@ -10,9 +10,3 @@
 
 NSString *const ZincTaskActionUpdate = @"UPDATE";
 NSString *const ZincTaskActionDelete = @"DELETE";
-
-//NSString *const ZincTaskActionGarbageCollect = @"GARBAGE-COLLECT";
-//NSString *const ZincTaskActionSourceUpdate = @"SOURCE-UPDATE";
-//NSString *const ZincTaskActionRepoIndexUpdate = @"
-//NSString *const ZincTaskActionRepoBundleClone;
-//NSString *const ZincTaskActionDownload;

--- a/Zinc/ZincTaskDescriptor.h
+++ b/Zinc/ZincTaskDescriptor.h
@@ -17,10 +17,11 @@
  * OS X.
  */
 
-+ (id) taskDescriptorWithResource:(NSURL*)resource method:(NSString*)method;
-- (id) initWithResource:(NSURL*)resource method:(NSString*)method;
++ (id) taskDescriptorWithResource:(NSURL*)resource action:(NSString*)action method:(NSString*)method;
+- (id) initWithResource:(NSURL*)resource action:(NSString*)action method:(NSString*)method;
 
 @property (nonatomic, retain, readonly) NSURL* resource;
+@property (nonatomic, retain, readonly) NSString* action;
 @property (nonatomic, retain, readonly) NSString* method;
 
 - (NSString*) stringValue;

--- a/Zinc/ZincTaskDescriptor.m
+++ b/Zinc/ZincTaskDescriptor.m
@@ -11,46 +11,52 @@
 
 @interface ZincTaskDescriptor ()
 @property (nonatomic, retain, readwrite) NSURL* resource;
+@property (nonatomic, retain, readwrite) NSURL* action;
 @property (nonatomic, retain, readwrite) NSString* method;
 @end
 
 @implementation ZincTaskDescriptor
 
 @synthesize resource = _resource;
+@synthesize action = _action;
 @synthesize method = _method;
 
-- (id) initWithResource:(NSURL*)resource method:(NSString*)method
+- (id) initWithResource:(NSURL*)resource action:(NSString*)action method:(NSString*)method
 {
     self = [super init];
     if (self) {
         self.resource = resource;
+        self.action = action;
         self.method = method;
     }
     return self;
 }
 
-+ (id) taskDescriptorWithResource:(NSURL*)resource method:(NSString*)method
++ (id) taskDescriptorWithResource:(NSURL*)resource action:(NSString*)action method:(NSString*)method
 {
-    return [[[self alloc] initWithResource:resource method:method] autorelease];
+    return [[[self alloc] initWithResource:resource action:action method:method] autorelease];
 }
 
 - (void)dealloc 
 {
     [_resource release];
+    [_action release];
     [_method release];
     [super dealloc];
 }
 
 - (NSString*) stringValue
 {
-    return [NSString stringWithFormat:@"%@|%@", [self.resource absoluteString], self.method];
+    return [NSString stringWithFormat:@"Resource=%@;Action=%@;Method=%@", 
+            [self.resource absoluteString], self.action, self.method];
 }
 
 - (id)copyWithZone:(NSZone *)zone
 {
     ZincTaskDescriptor* newdesc = [[ZincTaskDescriptor allocWithZone:zone] init];
-    newdesc.resource = [[self.resource copy] autorelease];
-    newdesc.method = [[self.method copy] autorelease];
+    newdesc.resource = [[self.resource copyWithZone:zone] autorelease];
+    newdesc.action = [[self.action copyWithZone:zone] autorelease];
+    newdesc.method = [[self.method copyWithZone:zone] autorelease];
     return newdesc;
 }
 
@@ -62,6 +68,9 @@
     
     ZincTaskDescriptor* other = (ZincTaskDescriptor*)object;
     if (![other.resource isEqual:self.resource]) {
+        return NO;
+    }
+    if (![other.action isEqual:self.action]) {
         return NO;
     }
     if (![other.method isEqual:self.method]) {

--- a/Zinc/ZincTaskDescriptor.m
+++ b/Zinc/ZincTaskDescriptor.m
@@ -11,7 +11,7 @@
 
 @interface ZincTaskDescriptor ()
 @property (nonatomic, retain, readwrite) NSURL* resource;
-@property (nonatomic, retain, readwrite) NSURL* action;
+@property (nonatomic, retain, readwrite) NSString* action;
 @property (nonatomic, retain, readwrite) NSString* method;
 @end
 

--- a/ZincDemo/AppDelegate.m
+++ b/ZincDemo/AppDelegate.m
@@ -92,10 +92,16 @@
     
     [repo resumeAllTasks];
 
-    [repo bootstrapBundleWithId:@"com.mindsnacks.demo1.cats" fromDir:[[NSBundle mainBundle] resourcePath] andTrack:@"master" waitUntilDone:YES];
-    [repo bootstrapBundleWithId:@"com.mindsnacks.demo1.sphalerites" fromDir:[[NSBundle mainBundle] resourcePath] andTrack:@"master" waitUntilDone:YES];
+    if (![repo bootstrapBundleWithId:@"com.mindsnacks.demo1.cats" fromDir:[[NSBundle mainBundle] resourcePath] waitUntilDone:YES]) {
+        abort();
+    }
+    
+//    if (![repo bootstrapBundleWithId:@"com.mindsnacks.demo1.sphalerites" fromDir:[[NSBundle mainBundle] resourcePath] waitUntilDone:YES]) {
+//        abort();
+//    }
 
-    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
+//    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
+//    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.sphalerites" distribution:@"master"];
 
     BundleListViewController* bundleListViewController = [[[BundleListViewController alloc] initWithRepo:repo] autorelease];
     

--- a/ZincDemo/AppDelegate.m
+++ b/ZincDemo/AppDelegate.m
@@ -90,13 +90,13 @@
     ZincRepo* repo = [[ZincRepo repoWithURL:repoURL error:&error] retain];
     repo.delegate = self;
     
-    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.sphalerites" distribution:@"master" automaticallyBootstrapFromPath:[[NSBundle mainBundle] resourcePath]];
-    
-    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
-    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.cats" distribution:@"master" automaticallyBootstrapFromPath:[[NSBundle mainBundle] resourcePath]];
-
     [repo resumeAllTasks];
-    
+
+    [repo bootstrapBundleWithId:@"com.mindsnacks.demo1.cats" fromDir:[[NSBundle mainBundle] resourcePath] andTrack:@"master" waitUntilDone:YES];
+    [repo bootstrapBundleWithId:@"com.mindsnacks.demo1.sphalerites" fromDir:[[NSBundle mainBundle] resourcePath] andTrack:@"master" waitUntilDone:YES];
+
+    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
+
     BundleListViewController* bundleListViewController = [[[BundleListViewController alloc] initWithRepo:repo] autorelease];
     
     UINavigationController* nc = [[[UINavigationController alloc] initWithRootViewController:bundleListViewController] autorelease];
@@ -104,7 +104,6 @@
     self.viewController = bundleListViewController;
     self.window.rootViewController = nc;
     [self.window makeKeyAndVisible];
-    
     
     return YES;
 }

--- a/ZincDemo/AppDelegate.m
+++ b/ZincDemo/AppDelegate.m
@@ -96,12 +96,13 @@
         abort();
     }
     
-//    if (![repo bootstrapBundleWithId:@"com.mindsnacks.demo1.sphalerites" fromDir:[[NSBundle mainBundle] resourcePath] waitUntilDone:YES]) {
-//        abort();
-//    }
+    if (![repo bootstrapBundleWithId:@"com.mindsnacks.demo1.sphalerites" fromDir:[[NSBundle mainBundle] resourcePath] waitUntilDone:YES]) {
+        abort();
+    }
 
-//    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
-//    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.sphalerites" distribution:@"master"];
+    [repo addSourceURL:[NSURL URLWithString:@"https://s3.amazonaws.com/zinc-demo/com.mindsnacks.demo1/"]];
+    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.cats" distribution:@"master"];
+    [repo beginTrackingBundleWithId:@"com.mindsnacks.demo1.sphalerites" distribution:@"master"];
 
     BundleListViewController* bundleListViewController = [[[BundleListViewController alloc] initWithRepo:repo] autorelease];
     


### PR DESCRIPTION
This (hopefully) improves bundle bootstrapping:
- Bootstrapping is now a separate command, rather than tacked onto tracking.
- If the bootstrap method can't find a valid manifest, it will error out immediately.
- You can wait for all bootstrap tasks to complete. I felt this would be a common need.
- This also fixes a bug where the same version of a bundle would be clone from a remote if it was already boostrapped (this is the action stuff I added).
