### PR TITLE
Fixing a retain cycle related ZincEvents

### DIFF
--- a/Zinc/ZincEvent.h
+++ b/Zinc/ZincEvent.h
@@ -24,6 +24,7 @@ typedef enum {
     ZincEventTypeGarbageCollectComplete,
 } ZincEventType;
 
+extern NSString *const kZincEventAttributesSourceKey;
 extern NSString *const kZincEventAttributesURLKey;
 extern NSString *const kZincEventAttributesPathKey;
 extern NSString *const kZincEventAttributesBundleResourceKey;
@@ -46,8 +47,6 @@ extern NSString *const kZincEventArchiveExtractCompleteNotification;
 extern NSString *const kZincEventGarbageCollectionBeginNotification;
 extern NSString *const kZincEventGarbageCollectionCompleteNotification;
 
-extern NSString *const kZincEventNotificationSourceKey;
-
 @interface ZincEvent : NSObject
 
 - (id) initWithType:(ZincEventType)type source:(id)source;
@@ -55,9 +54,7 @@ extern NSString *const kZincEventNotificationSourceKey;
 
 + (NSString*) name;
 
-//+ (id) eventWithType:(ZincEventType)type source:(id)source
 @property (nonatomic, assign, readonly) ZincEventType type;
-@property (nonatomic, retain, readonly) id source;
 @property (nonatomic, retain, readonly) NSDate* timestamp;
 @property (nonatomic, retain, readonly) NSDictionary* attributes;
 

--- a/Zinc/ZincEvent.m
+++ b/Zinc/ZincEvent.m
@@ -9,6 +9,7 @@
 #import "ZincEvent.h"
 #import "ZincEvent+Private.h"
 
+NSString *const kZincEventAttributesSourceKey = @"source";
 NSString *const kZincEventAttributesURLKey = @"url";
 NSString *const kZincEventAttributesPathKey = @"path";
 NSString *const kZincEventAttributesBundleResourceKey = @"bundleResource";
@@ -29,11 +30,8 @@ NSString *const kZincEventArchiveExtractCompleteNotification = @"ZincEventArchiv
 NSString *const kZincEventGarbageCollectionBeginNotification = @"ZincEventGarbageCollectionBeginNotification";
 NSString *const kZincEventGarbageCollectionCompleteNotification = @"ZincEventGarbageCollectionCompleteNotification";
 
-NSString *const kZincEventNotificationSourceKey = @"source";
-
 @interface ZincEvent ()
 @property (nonatomic, assign, readwrite) ZincEventType type;
-@property (nonatomic, retain, readwrite) id source;
 @property (nonatomic, retain, readwrite) NSDate* timestamp;
 @property (nonatomic, retain, readwrite) NSDictionary* attributes;
 @end
@@ -41,7 +39,6 @@ NSString *const kZincEventNotificationSourceKey = @"source";
 @implementation ZincEvent
 
 @synthesize type = _type;
-@synthesize source = _source;
 @synthesize timestamp = _timestamp;
 @synthesize attributes = _attributes;
 
@@ -50,9 +47,14 @@ NSString *const kZincEventNotificationSourceKey = @"source";
     self = [super init];
     if (self) {
         self.type = type;
-        self.source = source;
         self.timestamp = [NSDate date];
-        self.attributes = attributes;
+        if (source != nil) {
+            NSMutableDictionary *mutableAttributes = [[attributes mutableCopy] autorelease];;
+            [mutableAttributes setObject:[source description] forKey:kZincEventAttributesSourceKey];
+            self.attributes = mutableAttributes;
+        } else {
+            self.attributes = attributes;
+        }
     }
     return self;
 }
@@ -64,7 +66,6 @@ NSString *const kZincEventNotificationSourceKey = @"source";
 
 - (void)dealloc
 {
-    [_source release];
     [_timestamp release];
     [_attributes release];
     [super dealloc];

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -1146,9 +1146,6 @@ static NSString* kvo_taskProgress = @"kvo_taskProgress";
             [blockself.delegate zincRepo:blockself didReceiveEvent:event];
         
         NSMutableDictionary* userInfo = [[event.attributes mutableCopy] autorelease];
-//        if (event.source != nil) {
-//            [userInfo setObject:event.source forKey:kZincEventNotificationSourceKey];
-//        }
         [[NSNotificationCenter defaultCenter] postNotificationName:[[event class] notificationName] object:self userInfo:userInfo];        
     }];
 }

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -1146,9 +1146,9 @@ static NSString* kvo_taskProgress = @"kvo_taskProgress";
             [blockself.delegate zincRepo:blockself didReceiveEvent:event];
         
         NSMutableDictionary* userInfo = [[event.attributes mutableCopy] autorelease];
-        if (event.source != nil) {
-            [userInfo setObject:event.source forKey:kZincEventNotificationSourceKey];
-        }
+//        if (event.source != nil) {
+//            [userInfo setObject:event.source forKey:kZincEventNotificationSourceKey];
+//        }
         [[NSNotificationCenter defaultCenter] postNotificationName:[[event class] notificationName] object:self userInfo:userInfo];        
     }];
 }


### PR DESCRIPTION
An event held a strong reference to it's source. Unfortunately, the
source would often hold a list of it's events, creating a retain cycle.
The source was just used for informational purproses, so now I'm
converting it to a string (via `description`) and storing it as a
regular event attribute.
