### PR TITLE
UIImage category fixes

### DIFF
--- a/Zinc/UIImage+Zinc.h
+++ b/Zinc/UIImage+Zinc.h
@@ -11,7 +11,7 @@
 @interface UIImage (Zinc)
 
 /* bundle can be an NSBundle or ZincBundle */
-+ (UIImage *)imageNamed:(NSString *)name inBundle:(id)bundle;
++ (UIImage *)zinc_imageNamed:(NSString *)name inBundle:(id)bundle;
 
 #pragma mark Private
 

--- a/Zinc/UIImage+Zinc.m
+++ b/Zinc/UIImage+Zinc.m
@@ -50,7 +50,7 @@
     return path;
 }
 
-+ (UIImage *)imageNamed:(NSString *)name inBundle:(id)bundle
++ (UIImage *)zinc_imageNamed:(NSString *)name inBundle:(id)bundle
 {
     if (bundle == [NSBundle mainBundle]) {
         return [self imageNamed:name];

--- a/ZincDemo/AppDelegate.m
+++ b/ZincDemo/AppDelegate.m
@@ -57,11 +57,11 @@
     }
          
     NSBundle* bundle = [NSBundle bundleWithPath:dstDir];
-    UIImage* image1 = [UIImage imageNamed:@"sphalerite.jpg" inBundle:bundle];
+    UIImage* image1 = [UIImage zinc_imageNamed:@"sphalerite.jpg" inBundle:bundle];
     NSAssert(image1, @"image1 is nil");
     NSLog(@"image1: %@", NSStringFromCGSize(image1.size));
     
-    UIImage* image2 = [UIImage imageNamed:@"sphalerite@2x.jpg" inBundle:bundle];
+    UIImage* image2 = [UIImage zinc_imageNamed:@"sphalerite@2x.jpg" inBundle:bundle];
     NSAssert(image2, @"image1 is nil");
     NSLog(@"image2: %@", NSStringFromCGSize(image2.size));
 


### PR DESCRIPTION
Prefixed `imageNamed:(NSString *)name inBundle:(id)bundle` to prevent issues.
