### PR TITLE
Added 'context' to ZincBundleCloneBeginEvent

### DIFF
--- a/Zinc/ZincBundleCloneTask.m
+++ b/Zinc/ZincBundleCloneTask.m
@@ -43,7 +43,7 @@
 - (void) setUp
 {
     self.fileManager = [[[NSFileManager alloc] init] autorelease];
-    [self addEvent:[ZincBundleCloneBeginEvent bundleCloneBeginEventForBundleResource:self.resource source:self]];
+    [self addEvent:[ZincBundleCloneBeginEvent bundleCloneBeginEventForBundleResource:self.resource source:self context:self.bundleId]];
 }
 
 - (void) complete

--- a/Zinc/ZincEvent.h
+++ b/Zinc/ZincEvent.h
@@ -106,9 +106,10 @@ extern NSString *const kZincEventGarbageCollectionCompleteNotification;
 
 @interface ZincBundleCloneBeginEvent : ZincEvent 
 
-+ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource;
-+ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource source:(id)source;
++ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource context:(id)context;
++ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource source:(id)source context:(id)context;
 @property (readonly) NSURL* bundleResource;
+@property (readonly) id context;
 
 @end
 

--- a/Zinc/ZincEvent.m
+++ b/Zinc/ZincEvent.m
@@ -272,17 +272,18 @@ NSString *const kZincEventGarbageCollectionCompleteNotification = @"ZincEventGar
 
 @implementation ZincBundleCloneBeginEvent
 
-+ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource source:(id)source
++ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource source:(id)source context:(id)context
 {
     NSDictionary* attr = [NSDictionary dictionaryWithObjectsAndKeys:
-                          bundleResource, kZincEventAttributesBundleResourceKey, nil];
+                          bundleResource, kZincEventAttributesBundleResourceKey,
+                          context ?: [NSNull null], kZincEventAttributesContextKey, nil];
     
     return [[[self alloc] initWithType:ZincEventTypeBundleCloneBegin source:source attributes:attr] autorelease];
 }
 
-+ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource
++ (id) bundleCloneBeginEventForBundleResource:(NSURL*)bundleResource context:(id)context
 {
-    return [self bundleCloneBeginEventForBundleResource:bundleResource source:nil];
+    return [self bundleCloneBeginEventForBundleResource:bundleResource source:nil context:context];
 }
 
 + (NSString*) name
@@ -298,6 +299,11 @@ NSString *const kZincEventGarbageCollectionCompleteNotification = @"ZincEventGar
 - (NSURL*) bundleResource
 {
     return [self.attributes objectForKey:kZincEventAttributesBundleResourceKey];
+}
+
+- (id)context
+{
+    return [self.attributes objectForKey:kZincEventAttributesContextKey];
 }
 
 @end


### PR DESCRIPTION
Needed to track what bundle was the one being cloned.
