### PR TITLE
Improved download policy observation

### DIFF
--- a/Zinc/ZincBundleRemoteCloneTask.m
+++ b/Zinc/ZincBundleRemoteCloneTask.m
@@ -169,6 +169,11 @@
     return YES;
 }
 
+- (BOOL) isReady
+{
+    return [super isReady] && [self.repo doesPolicyAllowDownloadForBundleID:self.bundleId];
+}
+
 - (void) main
 {
     [self setUp];

--- a/Zinc/ZincRepo+Private.h
+++ b/Zinc/ZincRepo+Private.h
@@ -59,6 +59,7 @@
 - (ZincTask*) queueTaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor input:(id)input;
 - (ZincTask*) queueTaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor input:(id)input dependencies:(NSArray*)dependencies;
 - (void) addOperation:(NSOperation*)operation;
+- (BOOL) doesPolicyAllowDownloadForBundleID:(NSString*)bundleID;
 
 #pragma mark Paths
 

--- a/Zinc/ZincTask+Private.h
+++ b/Zinc/ZincTask+Private.h
@@ -38,4 +38,10 @@
 - (void)setShouldExecuteAsBackgroundTask;
 #endif
 
+
+/**
+ * @discussion Called to update isReady periodically. Default implementation just fires willChange/didChange on isReady key to force isReady to be called again. Subclasses may override.
+ */
+- (void) updateReadiness;
+
 @end

--- a/Zinc/ZincTask.m
+++ b/Zinc/ZincTask.m
@@ -189,6 +189,12 @@ static const NSString* kvo_SubtaskIsFinished = @"kvo_SubtaskIsFinished";
     return allErrors;
 }
 
+- (void) updateReadiness
+{
+    [self willChangeValueForKey:NSStringFromSelector(@selector(isReady))];
+    [self didChangeValueForKey:NSStringFromSelector(@selector(isReady))];
+}
+
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
 - (void)setShouldExecuteAsBackgroundTask
 {


### PR DESCRIPTION
Previously, the donwload policy was only checked when the task was enqueued.
Now it's checked in isReady, meaning that it's more compliant with wifi/3g changes.
