### PR TITLE
Feature/revamp bootstrapping

### DIFF
--- a/Zinc-ObjC.xcodeproj/project.pbxproj
+++ b/Zinc-ObjC.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		B340FA05148D608D00206F86 /* NSFileManager+Zinc.m in Sources */ = {isa = PBXBuildFile; fileRef = B340FA03148D608D00206F86 /* NSFileManager+Zinc.m */; };
 		B340FA0C148D67C400206F86 /* SenTestCase+MethodSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = B340FA0B148D67C400206F86 /* SenTestCase+MethodSwizzling.m */; };
 		B340FA0F148D7DC100206F86 /* ZincErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = B340FA0E148D7DC100206F86 /* ZincErrors.h */; };
+		B34199F0162F6F0300B9287C /* ZincImportExternalBundleTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B34199EE162F6F0300B9287C /* ZincImportExternalBundleTask.h */; };
+		B34199F1162F6F0300B9287C /* ZincImportExternalBundleTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B34199EF162F6F0300B9287C /* ZincImportExternalBundleTask.m */; };
 		B347EBE015C3593500FA0649 /* ZincOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B347EBDE15C3593500FA0649 /* ZincOperation.h */; };
 		B347EBE115C3593500FA0649 /* ZincOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B347EBDF15C3593500FA0649 /* ZincOperation.m */; };
 		B3549DEF148DB80900DD63D1 /* ZincManifest.h in Headers */ = {isa = PBXBuildFile; fileRef = B3549DED148DB80900DD63D1 /* ZincManifest.h */; };
@@ -261,6 +263,8 @@
 		B340FA0B148D67C400206F86 /* SenTestCase+MethodSwizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SenTestCase+MethodSwizzling.m"; sourceTree = "<group>"; };
 		B340FA0D148D6F0F00206F86 /* TestUtility-Zinc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TestUtility-Zinc.h"; sourceTree = "<group>"; };
 		B340FA0E148D7DC100206F86 /* ZincErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincErrors.h; sourceTree = "<group>"; };
+		B34199EE162F6F0300B9287C /* ZincImportExternalBundleTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincImportExternalBundleTask.h; sourceTree = "<group>"; };
+		B34199EF162F6F0300B9287C /* ZincImportExternalBundleTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincImportExternalBundleTask.m; sourceTree = "<group>"; };
 		B347EBDE15C3593500FA0649 /* ZincOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincOperation.h; sourceTree = "<group>"; };
 		B347EBDF15C3593500FA0649 /* ZincOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincOperation.m; sourceTree = "<group>"; };
 		B3549DED148DB80900DD63D1 /* ZincManifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincManifest.h; sourceTree = "<group>"; };
@@ -648,6 +652,8 @@
 				B327070814BC20F7004E3244 /* ZincBundleRemoteCloneTask.h */,
 				B327070914BC20F8004E3244 /* ZincBundleRemoteCloneTask.m */,
 				B396E3061590F56F00584F83 /* ZincBundleBootstrapTask.h */,
+				B34199EE162F6F0300B9287C /* ZincImportExternalBundleTask.h */,
+				B34199EF162F6F0300B9287C /* ZincImportExternalBundleTask.m */,
 				B396E3071590F56F00584F83 /* ZincBundleBootstrapTask.m */,
 				B3CEEC0014BE0F270023DF5B /* ZincBundleDeleteTask.h */,
 				B3CEEC0114BE0F270023DF5B /* ZincBundleDeleteTask.m */,
@@ -829,6 +835,7 @@
 				B3CAB60115FC6D0C008502AC /* ZincBundleAvailabilityMonitor.h in Headers */,
 				B3CF24F5160A6D260009E569 /* ZincHTTPRequestOperation.h in Headers */,
 				B3CF24F7160A6D260009E569 /* ZincURLConnectionOperation.h in Headers */,
+				B34199F0162F6F0300B9287C /* ZincImportExternalBundleTask.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1044,6 +1051,7 @@
 				B3CAB60615FD2617008502AC /* ZincProgress.m in Sources */,
 				B3CF24F6160A6D260009E569 /* ZincHTTPRequestOperation.m in Sources */,
 				B3CF24F8160A6D260009E569 /* ZincURLConnectionOperation.m in Sources */,
+				B34199F1162F6F0300B9287C /* ZincImportExternalBundleTask.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Zinc/ZincBundleTrackingRequest.h
+++ b/Zinc/ZincBundleTrackingRequest.h
@@ -45,21 +45,4 @@
                                                     distribution:(NSString*)distribution
                                              automaticallyUpdate:(BOOL)automaticallyUpdate;
 
-/**
- * @discussion Convenience constructor for bootstrap operations with flavor.
- * Distribution and automatic updates are ignored for bootstrap operations, so
- * they are omitted.
- */
-+ (ZincBundleTrackingRequest*) bundleTrackingRequestWithBundleID:(NSString*)bundleID
-                                                          flavor:(NSString*)flavor;
-
-/**
- * @discussion Convenience constructor for bootstrap operation.
- * Distribution and automatic updates are ignored for bootstrap operations, so
- * they are omitted.
- */
-+ (ZincBundleTrackingRequest*) bundleTrackingRequestWithBundleID:(NSString*)bundleID;
-
-
-
 @end

--- a/Zinc/ZincBundleTrackingRequest.m
+++ b/Zinc/ZincBundleTrackingRequest.m
@@ -42,21 +42,4 @@
     return req;
 }
 
-+ (ZincBundleTrackingRequest*) bundleTrackingRequestWithBundleID:(NSString*)bundleID
-                                                          flavor:(NSString*)flavor
-{
-    ZincBundleTrackingRequest* req = [[[ZincBundleTrackingRequest alloc] init] autorelease];
-    req.bundleID = bundleID;
-    req.flavor = flavor;
-    return req;
-}
-
-+ (ZincBundleTrackingRequest*) bundleTrackingRequestWithBundleID:(NSString*)bundleID
-{
-    ZincBundleTrackingRequest* req = [[[ZincBundleTrackingRequest alloc] init] autorelease];
-    req.bundleID = bundleID;
-    return req;
-}
-
-
 @end

--- a/Zinc/ZincImportExternalBundleTask.h
+++ b/Zinc/ZincImportExternalBundleTask.h
@@ -1,0 +1,13 @@
+//
+//  ZincImportExternalBundleTask.h
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 10/17/12.
+//  Copyright (c) 2012 MindSnacks. All rights reserved.
+//
+
+#import "ZincTask.h"
+
+@interface ZincImportExternalBundleTask : ZincTask
+
+@end

--- a/Zinc/ZincImportExternalBundleTask.m
+++ b/Zinc/ZincImportExternalBundleTask.m
@@ -1,0 +1,90 @@
+//
+//  ZincImportExternalBundleTask.m
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 10/17/12.
+//  Copyright (c) 2012 MindSnacks. All rights reserved.
+//
+
+#import "ZincImportExternalBundleTask.h"
+#import "ZincTask+Private.h"
+#import "ZincTaskActions.h"
+#import "ZincResource.h"
+#import "ZincManifest.h"
+#import "ZincEvent.h"
+#import "ZincRepo+Private.h"
+
+@interface ZincImportExternalBundleTask ()
+@property (retain) NSFileManager* fileManager;
+@end
+
+@implementation ZincImportExternalBundleTask
+
+@synthesize fileManager = _fileManager;
+
++ (NSString *)action
+{
+    return ZincTaskActionUpdate;
+}
+
+- (void)dealloc
+{
+    [_fileManager release];
+    [super dealloc];
+}
+
+- (NSString*) bundleId
+{
+    return [self.resource zincBundleId];
+}
+
+- (ZincVersion) version
+{
+    return [self.resource zincBundleVersion];
+}
+
+- (BOOL) prepareObjectFileWithManifest:(ZincManifest*)manifest fileRootPath:(NSString*)fileRootPath
+{
+    NSError* error = nil;
+    
+    NSString* flavor = [self.repo.index trackedFlavorForBundleId:self.bundleId];
+    
+    // make sha-based links in the repo to files inside the main bundle
+    NSArray* allFiles = [manifest filesForFlavor:flavor];
+    for (NSString* file in allFiles) {
+        NSString* sha = [manifest shaForFile:file];
+        NSString* srcPath = [fileRootPath stringByAppendingPathComponent:file];
+        NSString* dstPath = [self.repo pathForFileWithSHA:sha];
+        if (![self.fileManager fileExistsAtPath:dstPath]) {
+            if (![self.fileManager createSymbolicLinkAtPath:dstPath withDestinationPath:srcPath error:&error]) {
+                [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+                return NO;
+            }
+        }
+    }
+    return YES;
+}
+
+- (void) main
+{
+    self.fileManager = [[[NSFileManager alloc] init] autorelease];
+    
+    NSError* error = nil;
+    
+    ZincManifest* manifest = [self.repo manifestWithBundleId:self.bundleId version:self.version error:&error];
+    if (manifest == nil) {
+        [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+        return;
+    }
+    
+    NSString* fileRootPath = [self.repo pathForBundleWithId:self.bundleId version:self.version];
+    
+    if (![self prepareObjectFileWithManifest:manifest fileRootPath:fileRootPath]) {
+        return;
+    }
+    
+    self.finishedSuccessfully = YES;
+}
+
+
+@end

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -92,13 +92,19 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 
 - (void) refreshSourcesWithCompletion:(dispatch_block_t)completion;
 
-#pragma mark Bundles
+#pragma External Bundles
 
 - (BOOL) registerExternalBundleWithManifestPath:(NSString*)manifestPath bundleRootPath:(NSString*)rootPath error:(NSError**)outError;
+
+#pragma mark Tracking Remote Bundles
 
 - (void) beginTrackingBundleWithRequest:(ZincBundleTrackingRequest*)req;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro automaticallyUpdate:(BOOL)autoUpdate;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro flavor:(NSString*)flavor automaticallyUpdate:(BOOL)autoUpdate;
+
+#pragma mark Old-Style Bootstrapping (Deprecated)
+
+- (void) bootstrapBundleWithRequest:(ZincBundleTrackingRequest*)req fromDir:(NSString*)dir completionBlock:(ZincCompletionBlock)completion;
 
 /**
  @discussion Manually update a bundle. Currently ignores downloadPolicy and will update regardles

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -94,8 +94,7 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 
 #pragma mark Bundles
 
-- (void) bootstrapBundleWithRequest:(ZincBundleTrackingRequest*)req fromDir:(NSString*)dir completionBlock:(ZincCompletionBlock)completion;
-- (ZincTaskRef*) bootstrapBundleWithRequest:(ZincBundleTrackingRequest*)req fromDir:(NSString*)dir;
+- (BOOL) registerExternalBundleWithManifestPath:(NSString*)manifestPath bundleRootPath:(NSString*)rootPath error:(NSError**)outError;
 
 - (void) beginTrackingBundleWithRequest:(ZincBundleTrackingRequest*)req;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro automaticallyUpdate:(BOOL)autoUpdate;
@@ -118,8 +117,6 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 
 - (ZincBundle*) bundleWithId:(NSString*)bundleId;
 
-// NOTE: this may be removed soon
-- (void) waitForAllBootstrapTasks;
 
 #pragma mark Tasks
 

--- a/Zinc/ZincRepoIndex.h
+++ b/Zinc/ZincRepoIndex.h
@@ -40,6 +40,14 @@
 
 - (ZincVersion) newestAvailableVersionForBundleId:(NSString*)bundleId;
 
+#pragma mark External Bundles
+/* 
+ !!!: External bundles are not persisted by design, they should be re-registered each launch.
+ */
+
+- (void) registerExternalBundle:(NSURL*)bundleRes rootPath:(NSString*)rootPath;
+- (NSString*) externalPathForBundle:(NSURL*)bundleRes;
+
 #pragma mark Encoding
 
 + (id) repoIndexFromDictionary:(NSDictionary*)dict error:(NSError**)outError;

--- a/Zinc/ZincRepoIndex.h
+++ b/Zinc/ZincRepoIndex.h
@@ -48,6 +48,8 @@
 - (void) registerExternalBundle:(NSURL*)bundleRes rootPath:(NSString*)rootPath;
 - (NSString*) externalPathForBundle:(NSURL*)bundleRes;
 
+- (NSArray*) registeredExternalBundles;
+
 #pragma mark Encoding
 
 + (id) repoIndexFromDictionary:(NSDictionary*)dict error:(NSError**)outError;

--- a/Zinc/ZincRepoIndex.m
+++ b/Zinc/ZincRepoIndex.m
@@ -223,6 +223,13 @@
     }
 }
 
+- (NSArray*) registeredExternalBundles
+{
+    @synchronized(self.myExternalBundleRefs) {
+        return [self.myExternalBundleRefs allKeys];
+    }
+}
+
 - (NSSet*) bundlesWithState:(ZincBundleState)targetState
 {
     NSMutableSet* set = nil;

--- a/Zinc/ZincRepoIndex.m
+++ b/Zinc/ZincRepoIndex.m
@@ -16,6 +16,7 @@
 @interface ZincRepoIndex ()
 @property (nonatomic, retain) NSMutableSet* mySourceURLs;
 @property (nonatomic, retain) NSMutableDictionary* myBundles;
+@property (nonatomic, retain) NSMutableDictionary* myExternalBundleRefs;
 @end
 
 
@@ -30,6 +31,7 @@
     if (self) {
         self.mySourceURLs = [NSMutableSet set];
         self.myBundles = [NSMutableDictionary dictionary];
+        self.myExternalBundleRefs = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -38,6 +40,7 @@
 {
     [_mySourceURLs release];
     [_myBundles release];
+    [_myExternalBundleRefs release];
     [super dealloc];
 }
 
@@ -179,15 +182,20 @@
 
 - (ZincBundleState) stateForBundle:(NSURL*)bundleResource
 {
-    ZincBundleState state = ZincBundleStateNone;
+    @synchronized(self.myExternalBundleRefs) {
+        NSString* rootPath = self.myExternalBundleRefs[bundleResource];
+        if (rootPath != nil) {
+            return ZincBundleStateAvailable;
+        }
+    }
     @synchronized(self.myBundles) {
         NSString* bundleId = [bundleResource zincBundleId];
         ZincVersion bundleVersion = [bundleResource zincBundleVersion];
         NSMutableDictionary* bundleInfo = [self bundleInfoDictForId:bundleId createIfMissing:NO];
         NSMutableDictionary* versionInfo = [bundleInfo objectForKey:@"versions"];
-        state = [[versionInfo objectForKey:[[NSNumber numberWithInteger:bundleVersion] stringValue]] integerValue];
+        ZincBundleState state = [[versionInfo objectForKey:[[NSNumber numberWithInteger:bundleVersion] stringValue]] integerValue];
+        return state;
     }
-    return state;
 }
 
 - (void) removeBundle:(NSURL*)bundleResource
@@ -198,6 +206,20 @@
         NSDictionary* bundleInfo = [self bundleInfoDictForId:bundleId createIfMissing:NO];
         NSMutableDictionary* versionInfo = [bundleInfo objectForKey:@"versions"];
         [versionInfo removeObjectForKey:[[NSNumber numberWithInteger:bundleVersion] stringValue]];
+    }
+}
+
+- (void) registerExternalBundle:(NSURL*)bundleRes rootPath:(NSString*)rootPath
+{
+    @synchronized(self.myExternalBundleRefs) {
+        self.myExternalBundleRefs[bundleRes] = rootPath;
+    }
+}
+
+- (NSString*) externalPathForBundle:(NSURL*)bundleRes
+{
+    @synchronized(self.myExternalBundleRefs) {
+        return self.myExternalBundleRefs[bundleRes];
     }
 }
 
@@ -217,6 +239,11 @@
                     [set addObject:[NSURL zincResourceForBundleWithId:bundleId version:[version integerValue]]];
                 }
             }
+        }
+    }
+    if (targetState == ZincBundleStateAvailable) {
+        @synchronized(self.myExternalBundleRefs) {
+            [set addObjectsFromArray:[self.myExternalBundleRefs allKeys]];
         }
     }
     return set;
@@ -244,6 +271,15 @@
             [versions addObject:[NSNumber numberWithInteger:version]];
         }
     }];
+    
+    @synchronized(self.myExternalBundleRefs) {
+        [self.myExternalBundleRefs enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            NSURL* bundleRes = key;
+            if ([[bundleRes zincBundleId] isEqualToString:bundleId]) {
+                [versions addObject:[NSNumber numberWithInteger:[bundleRes zincBundleVersion]]];
+            }
+        }];
+    }
     
     return [versions sortedArrayUsingSelector:@selector(compare:)];
 }

--- a/ZincDemo/AppDelegate.m
+++ b/ZincDemo/AppDelegate.m
@@ -101,7 +101,8 @@
     
     for (NSString* bundleId in bundleIdsToBootstrap) {
         
-        ZincBundleTrackingRequest* req = [ZincBundleTrackingRequest bundleTrackingRequestWithBundleID:bundleId];
+        ZincBundleTrackingRequest* req = [[[ZincBundleTrackingRequest alloc] init] autorelease];
+        req.bundleID = bundleId;
         
         [repo bootstrapBundleWithRequest:req fromDir:[[NSBundle mainBundle] resourcePath] completionBlock:^(NSArray *errors) {
             if ([errors count] > 0) {


### PR DESCRIPTION
This allows zinc to read files and serve files directly from the main app bundle, without copying them into the repo first.

It will make SHA-based symlink to the files in the main app bundle, so Zinc will know it doesn't need to download them.
