### PR TITLE
Error while Cloning fix

### DIFF
--- a/Zinc/ZincBundleBootstrapTask.m
+++ b/Zinc/ZincBundleBootstrapTask.m
@@ -82,6 +82,7 @@
     ZincManifest* manifest = [self importManifestWithPath:manifestPath error:&error];
     if (manifest == nil) {
         [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+        [self completeWithSuccess:NO];
         return;
     }
     
@@ -96,25 +97,31 @@
         [self addOperation:extractOp];
         
         [extractOp waitUntilFinished];
-        if (self.isCancelled) return;
+        if (self.isCancelled) {
+            [self completeWithSuccess:NO];
+            return;
+        };
 
         if (extractOp.error != nil) {
             [self addEvent:[ZincErrorEvent eventWithError:extractOp.error source:self]];
+            [self completeWithSuccess:NO];
             return;
         }
         
     } else {
     
         if (![self prepareObjectFileWithManifest:manifest fileRootPath:fileRootPath]) {
+            [self completeWithSuccess:NO];
             return;
         }
     }
     
     if (![self createBundleLinksForManifest:manifest]) {
+        [self completeWithSuccess:NO];
         return;
     }
     
-    [self complete];
+    [self completeWithSuccess:YES];
 }
 
 @end

--- a/Zinc/ZincBundleCloneTask+Private.h
+++ b/Zinc/ZincBundleCloneTask+Private.h
@@ -15,7 +15,7 @@
 @property (retain) NSFileManager* fileManager;
 
 - (void) setUp;
-- (void) complete;
+- (void) completeWithSuccess:(BOOL)success;
 
 - (NSString*) getTrackedFlavor;
 

--- a/Zinc/ZincBundleCloneTask.m
+++ b/Zinc/ZincBundleCloneTask.m
@@ -52,11 +52,17 @@
     [self addEvent:[ZincBundleCloneBeginEvent bundleCloneBeginEventForBundleResource:self.resource source:self context:self.bundleId]];
 }
 
-- (void) complete
+- (void) completeWithSuccess:(BOOL)success
 {
-    [self.repo registerBundle:self.resource status:ZincBundleStateAvailable];
-    [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
-    self.finishedSuccessfully = YES;
+    if (success) {
+        [self.repo registerBundle:self.resource status:ZincBundleStateAvailable];
+        [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
+    } else {
+        [self.repo registerBundle:self.resource status:ZincBundleStateNone];
+        [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
+    }
+    
+    self.finishedSuccessfully = success;
 }
 
 - (BOOL) createBundleLinksForManifest:(ZincManifest*)manifest

--- a/Zinc/ZincBundleCloneTask.m
+++ b/Zinc/ZincBundleCloneTask.m
@@ -56,12 +56,11 @@
 {
     if (success) {
         [self.repo registerBundle:self.resource status:ZincBundleStateAvailable];
-        [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
     } else {
         [self.repo registerBundle:self.resource status:ZincBundleStateNone];
-        [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
     }
-    
+
+    [self addEvent:[ZincBundleCloneCompleteEvent bundleCloneCompleteEventForBundleResource:self.resource source:self context:self.bundleId]];
     self.finishedSuccessfully = success;
 }
 

--- a/Zinc/ZincBundleRemoteCloneTask.m
+++ b/Zinc/ZincBundleRemoteCloneTask.m
@@ -181,24 +181,28 @@
     NSError* error = nil;
     
     if (![self prepareManifest]) {
+        [self completeWithSuccess:NO];
         return;
     }
     
     ZincManifest* manifest = [self.repo manifestWithBundleId:self.bundleId version:self.version error:&error];
     if (manifest == nil) {
         [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+        [self completeWithSuccess:NO];
         return;
     }
     
     if (![self prepareObjectFilesUsingRemoteCatalogForManifest:manifest]) {
+        [self completeWithSuccess:NO];
         return;
     }
     
     if (![self createBundleLinksForManifest:manifest]) {
+        [self completeWithSuccess:NO];
         return;
     }
     
-    [self complete];
+    [self completeWithSuccess:YES];
 }
 
 @end


### PR DESCRIPTION
If a bundle failed to clone (for whatever reason) it's status was left at
'cloning'. This would cause Zinc to try to resume cloning again later. However,
it would keep attempting to clone the exact bundle _version_. This can be a
problem if that version was deleted. Now, if cloning fails, it sets the bundle
status back to 'None', and the regular tracking logic will pick up a new version.
