### PR TITLE
Fixing failure on recoverable error in gzip routine.

### DIFF
--- a/Zinc/ZincGzip.m
+++ b/Zinc/ZincGzip.m
@@ -1,4 +1,4 @@
-	//
+//
 //  ZincGzip.m
 //  Zinc-ObjC
 //


### PR DESCRIPTION
Turns out, gzip error checking was overly strict. A Z_BUF_ERROR is safe to
ignore. See http://www.zlib.net/zlib_how.html for more information.
