### PR TITLE
Refresh sources in addition to bundles when reachability changes.

### DIFF
--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -299,7 +299,9 @@ static NSString* kvo_taskIsFinished = @"kvo_taskIsFinished";
                 
                 [remoteBundleUpdateTasks makeObjectsPerformSelector:@selector(updateReadiness)];
             }
-            [blockself refreshBundlesWithCompletion:nil];
+            [blockself refreshSourcesWithCompletion:^{
+                [blockself refreshBundlesWithCompletion:nil];
+            }];
         };
     }
 }


### PR DESCRIPTION
- Added a line to refresh the sources when reachability changes in order to prevent users from waiting for an auto-refresh if they get/enable connectivity while waiting for a download.
