### PR TITLE
Reworking clean symlinks and creating repo format 2

### DIFF
--- a/Zinc Functional Tests/DemoCatalogTests.m
+++ b/Zinc Functional Tests/DemoCatalogTests.m
@@ -465,8 +465,6 @@
 
 - (void)testCleanRemovesObjectWithSymlinksIfFlagIfVersionIs1
 {
-//    GHFail(@"this test is broken");
-    
     NSError* error = nil;
     
     [self refreshCatalog];
@@ -649,12 +647,6 @@
     
     ZincBundleState state = [self.zincRepo stateForBundleWithId:bundleID];
     GHAssertEquals(state, ZincBundleStateNone, @"should not be available");
-    
-    
-
-    
-
-
 }
 
 @end

--- a/Zinc Functional Tests/ZincFunctionalTestCase.h
+++ b/Zinc Functional Tests/ZincFunctionalTestCase.h
@@ -10,7 +10,7 @@
 
 #import "Zinc.h"
 
-@interface ZincFunctionalTestCase : GHAsyncTestCase
+@interface ZincFunctionalTestCase : GHAsyncTestCase <ZincRepoDelegate>
 
 @property (strong) ZincRepo *zincRepo;
 

--- a/Zinc Functional Tests/ZincFunctionalTestCase.m
+++ b/Zinc Functional Tests/ZincFunctionalTestCase.m
@@ -10,12 +10,18 @@
 
 @implementation ZincFunctionalTestCase
 
+- (void) zincRepo:(ZincRepo*)repo didReceiveEvent:(ZincEvent*)event
+{
+    NSLog(@"%@", event);
+}
+
 - (void)setupZincRepoWithRootDir:(NSString*)repoDir
 {
     NSError *error = nil;
     self.zincRepo = [ZincRepo repoWithURL:[NSURL fileURLWithPath:repoDir] error:&error];
     GHAssertNil(error, @"error: %@", error);
 
+    self.zincRepo.delegate = self;
     self.zincRepo.autoRefreshInterval = 0;
     [self.zincRepo resumeAllTasks];
 

--- a/Zinc-ObjC.xcodeproj/project.pbxproj
+++ b/Zinc-ObjC.xcodeproj/project.pbxproj
@@ -120,6 +120,10 @@
 		B38743191489B830004B227B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B38743181489B830004B227B /* AppDelegate.m */; };
 		B38A06F314C0DADC00AEC367 /* UIImage+Zinc.h in Headers */ = {isa = PBXBuildFile; fileRef = B38A06F114C0DADC00AEC367 /* UIImage+Zinc.h */; };
 		B38A06F414C0DADC00AEC367 /* UIImage+Zinc.m in Sources */ = {isa = PBXBuildFile; fileRef = B38A06F214C0DADC00AEC367 /* UIImage+Zinc.m */; };
+		B38E8BA016AA3063009C03BC /* ZincMaintenanceTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B38E8B9E16AA3063009C03BC /* ZincMaintenanceTask.h */; };
+		B38E8BA116AA3063009C03BC /* ZincMaintenanceTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B38E8B9F16AA3063009C03BC /* ZincMaintenanceTask.m */; };
+		B38E8CA916AA5468009C03BC /* ZincCleanLegacySymlinksTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B38E8CA716AA5468009C03BC /* ZincCleanLegacySymlinksTask.h */; };
+		B38E8CAA16AA5468009C03BC /* ZincCleanLegacySymlinksTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B38E8CA816AA5468009C03BC /* ZincCleanLegacySymlinksTask.m */; };
 		B393432D1588144200C81A4F /* sphalerite.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B393432B1588144200C81A4F /* sphalerite.jpg */; };
 		B393432E1588144200C81A4F /* sphalerite@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B393432C1588144200C81A4F /* sphalerite@2x.jpg */; };
 		B396E30C1590FB8D00584F83 /* ZincBundleCloneTask.h in Headers */ = {isa = PBXBuildFile; fileRef = B396E30A1590FB8C00584F83 /* ZincBundleCloneTask.h */; };
@@ -332,6 +336,10 @@
 		B38743181489B830004B227B /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		B38A06F114C0DADC00AEC367 /* UIImage+Zinc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Zinc.h"; sourceTree = "<group>"; };
 		B38A06F214C0DADC00AEC367 /* UIImage+Zinc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Zinc.m"; sourceTree = "<group>"; };
+		B38E8B9E16AA3063009C03BC /* ZincMaintenanceTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincMaintenanceTask.h; sourceTree = "<group>"; };
+		B38E8B9F16AA3063009C03BC /* ZincMaintenanceTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincMaintenanceTask.m; sourceTree = "<group>"; };
+		B38E8CA716AA5468009C03BC /* ZincCleanLegacySymlinksTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincCleanLegacySymlinksTask.h; sourceTree = "<group>"; };
+		B38E8CA816AA5468009C03BC /* ZincCleanLegacySymlinksTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincCleanLegacySymlinksTask.m; sourceTree = "<group>"; };
 		B393432B1588144200C81A4F /* sphalerite.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = sphalerite.jpg; path = com.mindsnacks.demo1.sphalerites/sphalerite.jpg; sourceTree = "<group>"; };
 		B393432C1588144200C81A4F /* sphalerite@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = "sphalerite@2x.jpg"; path = "com.mindsnacks.demo1.sphalerites/sphalerite@2x.jpg"; sourceTree = "<group>"; };
 		B396E30A1590FB8C00584F83 /* ZincBundleCloneTask.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = ZincBundleCloneTask.h; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; wrapsLines = 0; };
@@ -389,12 +397,12 @@
 		B3E46B9D14C4C00400030349 /* ZincRepoIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincRepoIndexTests.m; sourceTree = "<group>"; };
 		B3E743B615998B9F0098DB19 /* com.mindsnacks.demo1.cats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = com.mindsnacks.demo1.cats.json; sourceTree = "<group>"; };
 		B3E743B715998B9F0098DB19 /* com.mindsnacks.demo1.cats.tar */ = {isa = PBXFileReference; lastKnownFileType = archive.tar; path = com.mindsnacks.demo1.cats.tar; sourceTree = "<group>"; };
-		B3EACD8414BD4905004D90EC /* ZincGarbageCollectTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincGarbageCollectTask.h; sourceTree = "<group>"; };
-		B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincGarbageCollectTask.m; sourceTree = "<group>"; };
+		B3EACD8414BD4905004D90EC /* ZincGarbageCollectTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ZincGarbageCollectTask.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ZincGarbageCollectTask.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B3F14A5B15BB840900F7E22E /* ZincTaskActions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincTaskActions.h; sourceTree = "<group>"; };
 		B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincTaskActions.m; sourceTree = "<group>"; };
 		B3F8AF74148EFCDF00CB92B5 /* ZincRepo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincRepo.h; sourceTree = "<group>"; };
-		B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincRepo.m; sourceTree = "<group>"; };
+		B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ZincRepo.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		D00356D8153760220021627E /* ZincEvent+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZincEvent+Private.h"; sourceTree = "<group>"; };
 		DB6D028A71E24F89A1C495F7 /* libPods-Zinc Functional Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Zinc Functional Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -773,8 +781,12 @@
 				B327071D14BCE756004E3244 /* ZincObjectDownloadTask.m */,
 				B3316A2814C648F000AEAD6C /* ZincArchiveDownloadTask.h */,
 				B3316A2914C648F000AEAD6C /* ZincArchiveDownloadTask.m */,
+				B38E8B9E16AA3063009C03BC /* ZincMaintenanceTask.h */,
+				B38E8B9F16AA3063009C03BC /* ZincMaintenanceTask.m */,
 				B3EACD8414BD4905004D90EC /* ZincGarbageCollectTask.h */,
 				B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */,
+				B38E8CA716AA5468009C03BC /* ZincCleanLegacySymlinksTask.h */,
+				B38E8CA816AA5468009C03BC /* ZincCleanLegacySymlinksTask.m */,
 				B3BFF9DF15C62363005A879E /* ZincTaskRef.m */,
 			);
 			name = Tasks;
@@ -950,6 +962,8 @@
 				B36CA5C61632142B00843CEC /* ZincGzip.h in Headers */,
 				B32EE27616A4FE64000E772B /* ZincTrackingInfo.h in Headers */,
 				B33AEF9516A6321C0000B6C5 /* ZincExternalBundleInfo.h in Headers */,
+				B38E8BA016AA3063009C03BC /* ZincMaintenanceTask.h in Headers */,
+				B38E8CA916AA5468009C03BC /* ZincCleanLegacySymlinksTask.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1212,6 +1226,8 @@
 				B32EE27716A4FE64000E772B /* ZincTrackingInfo.m in Sources */,
 				B33AEF9616A6321C0000B6C5 /* ZincExternalBundleInfo.m in Sources */,
 				B33AF01216A641700000B6C5 /* ZincBundleTrackingRequest.m in Sources */,
+				B38E8BA116AA3063009C03BC /* ZincMaintenanceTask.m in Sources */,
+				B38E8CAA16AA5468009C03BC /* ZincCleanLegacySymlinksTask.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Zinc/ZincCleanLegacySymlinksTask.h
+++ b/Zinc/ZincCleanLegacySymlinksTask.h
@@ -1,0 +1,14 @@
+//
+//  ZincCleanLegacySymlinksTask.h
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 1/18/13.
+//  Copyright (c) 2013 MindSnacks. All rights reserved.
+//
+
+#import "ZincMaintenanceTask.h"
+
+@interface ZincCleanLegacySymlinksTask : ZincMaintenanceTask
+
+
+@end

--- a/Zinc/ZincCleanLegacySymlinksTask.m
+++ b/Zinc/ZincCleanLegacySymlinksTask.m
@@ -1,0 +1,85 @@
+//
+//  ZincCleanLegacySymlinksTask.m
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 1/18/13.
+//  Copyright (c) 2013 MindSnacks. All rights reserved.
+//
+
+#import "ZincCleanLegacySymlinksTask.h"
+#import "ZincTask+Private.h"
+#import "ZincRepo+Private.h"
+#import "ZincEvent.h"
+#import "ZincResource.h"
+
+@implementation ZincCleanLegacySymlinksTask
+
++ (NSString *)action
+{
+    return @"CleanLegacySymlinks";
+}
+
+- (void) cleanObjectsDir
+{
+    NSError* error = nil;
+    NSFileManager* fm = [[[NSFileManager alloc] init] autorelease];
+    NSDirectoryEnumerator* filesEnum = [fm enumeratorAtURL:[NSURL fileURLWithPath:[self.repo filesPath]]
+                                includingPropertiesForKeys:[NSArray arrayWithObjects:NSURLIsSymbolicLinkKey, nil]
+                                                   options:0
+                                              errorHandler:^(NSURL* url, NSError* error){
+                                                  return YES;
+                                              }];
+    for (NSURL *theURL in filesEnum) {
+        NSNumber *isSymlink;
+        if (![theURL getResourceValue:&isSymlink forKey:NSURLIsSymbolicLinkKey error:&error]) {
+            [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+            continue;
+        }
+        if ([isSymlink boolValue]) {
+            [fm removeItemAtURL:theURL error:NULL];
+        }
+    }
+}
+
+- (void) cleanBundlesDir
+{
+    NSError* error = nil;
+    NSFileManager* fm = [[[NSFileManager alloc] init] autorelease];
+    NSString* bundlesPath = [self.repo bundlesPath];
+    NSDirectoryEnumerator* bundlesEnum = [fm enumeratorAtURL:[NSURL fileURLWithPath:bundlesPath]
+                                  includingPropertiesForKeys:[NSArray arrayWithObjects:NSURLIsRegularFileKey, NSURLLinkCountKey, NSURLIsSymbolicLinkKey, nil]
+                                                     options:0
+                                                errorHandler:^(NSURL* url, NSError* error){
+                                                    return YES;
+                                                }];
+    NSMutableSet* bundlesToDelete = [NSMutableSet set];
+    for (NSURL *theURL in bundlesEnum) {
+        NSNumber *isSymlink;
+        if (![theURL getResourceValue:&isSymlink forKey:NSURLIsSymbolicLinkKey error:&error]) {
+            [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+            continue;
+        }
+        if ([isSymlink boolValue]) {
+            NSUInteger endIndexOfBundleDir = NSMaxRange([[theURL path] rangeOfString:bundlesPath]);
+            NSString* relPath = [[theURL path] substringFromIndex:endIndexOfBundleDir + 1];
+            NSString* bundleDesc = [[relPath pathComponents] objectAtIndex:0];
+            NSURL* bundleRes = [NSURL zincResourceForBundleDescriptor:bundleDesc];
+            [bundlesToDelete addObject:bundleRes];
+        }
+    }
+    for (NSURL* bundleRes in bundlesToDelete) {
+        NSString* path = [self.repo pathForBundleWithId:[bundleRes zincBundleId] version:[bundleRes zincBundleVersion]];
+        if (![fm removeItemAtPath:path error:&error]) {
+            [self addEvent:[ZincErrorEvent eventWithError:error source:self]];
+        }
+        [self.repo deregisterBundle:bundleRes];
+    }
+}
+
+- (void) doMaintenance
+{
+    [self cleanObjectsDir];
+    [self cleanBundlesDir];
+}
+
+@end

--- a/Zinc/ZincEvent.h
+++ b/Zinc/ZincEvent.h
@@ -19,8 +19,8 @@ typedef enum {
     ZincEventTypeBundleCloneComplete,
     ZincEventTypeArchiveExtractBegin,
     ZincEventTypeArchiveExtractComplete,
-    ZincEventTypeGarbageCollectBegin,
-    ZincEventTypeGarbageCollectComplete,
+    ZincEventTypeMaintenanceBegin,
+    ZincEventTypeMaintenanceComplete,
 } ZincEventType;
 
 extern NSString *const kZincEventAttributesSourceKey;
@@ -31,6 +31,7 @@ extern NSString *const kZincEventAttributesBundleResourceKey;
 extern NSString *const kZincEventAttributesArchiveResourceKey;
 extern NSString *const kZincEventAttributesContextKey;
 extern NSString *const kZincEventAttributesCloneSuccessKey;
+extern NSString *const kZincEventAttributesActionKey;
 
 #pragma mark Notifications
 
@@ -43,8 +44,8 @@ extern NSString *const kZincEventBundleCloneBeginNotification;
 extern NSString *const kZincEventBundleCloneCompleteNotification;
 extern NSString *const kZincEventArchiveExtractBeginNotification;
 extern NSString *const kZincEventArchiveExtractCompleteNotification;
-extern NSString *const kZincEventGarbageCollectionBeginNotification;
-extern NSString *const kZincEventGarbageCollectionCompleteNotification;
+extern NSString *const kZincEventMaintenanceBeginNotification;
+extern NSString *const kZincEventMaintenanceionCompleteNotification;
 
 @interface ZincEvent : NSObject
 
@@ -133,15 +134,17 @@ extern NSString *const kZincEventGarbageCollectionCompleteNotification;
 @end
 
 
-@interface ZincGarbageCollectionBeginEvent : ZincEvent
+@interface ZincMaintenanceBeginEvent : ZincEvent
 
-+ (id) event;
++ (id) maintenanceEventWithAction:(NSString*)category;
+@property (readonly) NSString* action;
 
 @end
 
 
-@interface ZincGarbageCollectionCompleteEvent : ZincEvent
+@interface ZincMaintenanceCompleteEvent : ZincEvent
 
-+ (id) event;
++ (id) maintenanceEventWithAction:(NSString*)action;
+@property (readonly) NSString* action;
 
 @end

--- a/Zinc/ZincEvent.m
+++ b/Zinc/ZincEvent.m
@@ -17,6 +17,7 @@ NSString *const kZincEventAttributesBundleResourceKey = @"bundleResource";
 NSString *const kZincEventAttributesArchiveResourceKey = @"archiveResource";
 NSString *const kZincEventAttributesContextKey = @"context";
 NSString *const kZincEventAttributesCloneSuccessKey = @"success";
+NSString *const kZincEventAttributesActionKey = @"action";
 
 NSString *const kZincEventErrorNotification = @"ZincEventErrorNotification";
 NSString *const kZincEventBundleUpdateNotification = @"ZincEventBundleUpdateNotification";
@@ -27,8 +28,8 @@ NSString *const kZincEventBundleCloneBeginNotification = @"ZincEventBundleCloneB
 NSString *const kZincEventBundleCloneCompleteNotification = @"ZincEventBundleCloneCompleteNotification";
 NSString *const kZincEventArchiveExtractBeginNotification = @"ZincEventArchiveExtractBeginNotification";
 NSString *const kZincEventArchiveExtractCompleteNotification = @"ZincEventArchiveExtractCompleteNotification";
-NSString *const kZincEventGarbageCollectionBeginNotification = @"ZincEventGarbageCollectionBeginNotification";
-NSString *const kZincEventGarbageCollectionCompleteNotification = @"ZincEventGarbageCollectionCompleteNotification";
+NSString *const kZincEventMaintenanceBeginNotification = @"ZincEventMaintenanceionBeginNotification";
+NSString *const kZincEventMaintenanceionCompleteNotification = @"ZincEventMaintenanceionCompleteNotification";
 
 @interface ZincEvent ()
 @property (nonatomic, assign, readwrite) ZincEventType type;
@@ -375,42 +376,57 @@ NSString *const kZincEventGarbageCollectionCompleteNotification = @"ZincEventGar
 @end
 
 
-@implementation ZincGarbageCollectionBeginEvent
+@implementation ZincMaintenanceBeginEvent
 
-+ (id) event
++ (id) maintenanceEventWithAction:(NSString*)category;
 {
-    return [[[self alloc] initWithType:ZincEventTypeGarbageCollectBegin source:nil] autorelease];
+    NSDictionary* attr = [NSDictionary dictionaryWithObjectsAndKeys:
+                          category, kZincEventAttributesActionKey, nil];
+    return [[[self alloc] initWithType:ZincEventTypeMaintenanceBegin source:nil attributes:attr] autorelease];
 }
 
 + (NSString*) name
 {
-    return @"GARBAGECOLLECT-BEGIN";
+    return @"MAINTENANCE-BEGIN";
 }
 
 + (NSString *)notificationName
 {
-    return kZincEventGarbageCollectionBeginNotification;
+    return kZincEventMaintenanceBeginNotification;
+}
+
+- (NSString*) action
+{
+    return self.attributes[kZincEventAttributesActionKey];
 }
 
 @end
 
 
-@implementation ZincGarbageCollectionCompleteEvent
+@implementation ZincMaintenanceCompleteEvent
 
-+ (id) event
++ (id) maintenanceEventWithAction:(NSString*)category
 {
-    return [[[self alloc] initWithType:ZincEventTypeGarbageCollectComplete source:nil] autorelease];
+    NSDictionary* attr = [NSDictionary dictionaryWithObjectsAndKeys:
+                          category, kZincEventAttributesActionKey, nil];
+    return [[[self alloc] initWithType:ZincEventTypeMaintenanceComplete source:nil attributes:attr] autorelease];
 }
 
 + (NSString*) name
 {
-    return @"GARBAGECOLLECT-COMPLETE";
+    return @"MAINTENANCE-COMPLETE";
 }
 
 + (NSString *)notificationName
 {
-    return kZincEventGarbageCollectionCompleteNotification;
+    return kZincEventMaintenanceionCompleteNotification;
 }
+
+- (NSString*) action
+{
+    return self.attributes[kZincEventAttributesActionKey];
+}
+
 @end
 
 

--- a/Zinc/ZincGarbageCollectTask.h
+++ b/Zinc/ZincGarbageCollectTask.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2012 MindSnacks. All rights reserved.
 //
 
-#import "ZincTask.h"
+#import "ZincMaintenanceTask.h"
 
-@interface ZincGarbageCollectTask : ZincTask
+@interface ZincGarbageCollectTask : ZincMaintenanceTask
 
 @end

--- a/Zinc/ZincMaintenanceTask.h
+++ b/Zinc/ZincMaintenanceTask.h
@@ -1,0 +1,19 @@
+//
+//  ZincMaintenanceTask.h
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 1/18/13.
+//  Copyright (c) 2013 MindSnacks. All rights reserved.
+//
+
+#import "ZincTask.h"
+
+@interface ZincMaintenanceTask : ZincTask
+
++ (ZincTaskDescriptor*) taskDescriptorForResource:(NSURL*)resource;
+
+#pragma mark Private
+
+- (void) doMaintenance;
+
+@end

--- a/Zinc/ZincMaintenanceTask.m
+++ b/Zinc/ZincMaintenanceTask.m
@@ -1,0 +1,40 @@
+//
+//  ZincMaintenanceTask.m
+//  Zinc-ObjC
+//
+//  Created by Andy Mroczkowski on 1/18/13.
+//  Copyright (c) 2013 MindSnacks. All rights reserved.
+//
+
+#import "ZincMaintenanceTask.h"
+#import "ZincTask+Private.h"
+#import "ZincEvent.h"
+#import "ZincTaskDescriptor.h"
+
+
+@implementation ZincMaintenanceTask
+
++ (NSString *)action
+{
+    NSAssert(NO, @"method must be defined by subclass");
+    return nil;
+}
+
++ (ZincTaskDescriptor*) taskDescriptorForResource:(NSURL*)resource
+{
+    return [ZincTaskDescriptor taskDescriptorWithResource:resource action:[self action] method:[self taskMethod]];
+}
+
+- (void) main
+{
+    [self addEvent:[ZincMaintenanceBeginEvent maintenanceEventWithAction:[[self class] action]]];
+    [self doMaintenance];
+    [self addEvent:[ZincMaintenanceCompleteEvent maintenanceEventWithAction:[[self class] action]]];
+}
+
+- (void)doMaintenance
+{
+    NSAssert(NO, @"method must be defined by subclass");
+}
+
+@end

--- a/Zinc/ZincOperationQueueGroup.h
+++ b/Zinc/ZincOperationQueueGroup.h
@@ -11,10 +11,9 @@
 @interface ZincOperationQueueGroup : NSObject
 
 - (void) setMaxConcurrentOperationCount:(NSInteger)cnt forClass:(Class)theClass;
+- (void) setIsBarrierOperationForClass:(Class)theClass;
 
 - (void) addOperation:(NSOperation*)operation;
-
-- (NSOperationQueue*) getQueueForClass:(Class)theClass;
 
 - (void)setSuspended:(BOOL)b;
 - (BOOL)isSuspended;

--- a/Zinc/ZincOperationQueueGroup.m
+++ b/Zinc/ZincOperationQueueGroup.m
@@ -205,7 +205,9 @@
     NSMutableArray* ops = [NSMutableArray array];
     NSArray* allInfos = [self.infoByClassName allValues];
     for (ZincOperationQueueGroupInfo* info in allInfos) {
-        [ops addObjectsFromArray:info.queue.operations];
+        if (info.queue != nil) {
+            [ops addObjectsFromArray:info.queue.operations];
+        }
     }
     return ops;
 }
@@ -217,7 +219,9 @@
         return ((ZincOperationQueueGroupInfo*)evaluatedObject).isBarrier;
     }]];
     for (ZincOperationQueueGroupInfo* info in barrierInfos) {
-        [ops addObjectsFromArray:info.queue.operations];
+        if (info.queue != nil) {
+            [ops addObjectsFromArray:info.queue.operations];
+        }
     }
     return ops;
 }

--- a/Zinc/ZincOperationQueueGroup.m
+++ b/Zinc/ZincOperationQueueGroup.m
@@ -9,9 +9,9 @@
 #import "ZincOperationQueueGroup.h"
 
 @interface ZincOperationQueueGroup ()
-@property (nonatomic, retain) NSMutableDictionary* infoByClassName;
+@property (atomic, retain) NSMutableDictionary* infoByClassName;
 @property (atomic) BOOL mySuspended;
-@property (nonatomic, retain) NSOperationQueue* defaultQueue;
+@property (atomic, retain) NSOperationQueue* defaultQueue;
 @end
 
 @interface ZincOperationQueueGroupInfo : NSObject

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -69,7 +69,7 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 @property (nonatomic, retain, readonly) NSURL* url;
 
 /**
- @discussion The repo may need to perform some initialization tasks. This will be NO until they are performed. Tasks will not run until 'resumeAllTasks' is ran initially
+ @discussion The repo may need to perform some initialization tasks. This will be NO until they are performed.
  */
 @property (nonatomic, assign, readonly) BOOL isInitialized;
 
@@ -117,7 +117,11 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro automaticallyUpdate:(BOOL)autoUpdate;
 - (void) beginTrackingBundleWithId:(NSString*)bundleId distribution:(NSString*)distro flavor:(NSString*)flavor automaticallyUpdate:(BOOL)autoUpdate;
 
-#pragma mark -
+- (void) stopTrackingBundleWithId:(NSString*)bundleId;
+
+- (NSSet*) trackedBundleIds;
+
+#pragma mark mark Updating Bundles
 
 /**
  @discussion Manually update a bundle. Currently ignores downloadPolicy and will update regardles
@@ -126,17 +130,22 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 - (void) updateBundleWithID:(NSString*)bundleId completionBlock:(ZincCompletionBlock)completion;
 - (ZincTaskRef*) updateBundleWithID:(NSString*)bundleID;
 
-- (void) stopTrackingBundleWithId:(NSString*)bundleId;
-
-- (NSSet*) trackedBundleIds;
-
+/**
+ @discussion Update all bundles
+ */
 - (void) refreshBundlesWithCompletion:(dispatch_block_t)completion;
+
+- (BOOL) doesPolicyAllowDownloadForBundleID:(NSString*)bundleID;
+
+#pragma mark -
+
+/**
+ @discussion Main, offical way to get a bundle of files. Will raise an exception if the repo is not initialized
+ */
+- (ZincBundle*) bundleWithId:(NSString*)bundleId;
 
 - (ZincBundleState) stateForBundleWithId:(NSString*)bundleId;
 
-- (ZincBundle*) bundleWithId:(NSString*)bundleId;
-
-- (BOOL) doesPolicyAllowDownloadForBundleID:(NSString*)bundleID;
 
 #pragma mark Tasks
 

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -69,6 +69,13 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 @property (nonatomic, retain, readonly) NSURL* url;
 
 /**
+ @discussion The repo may need to perform some initialization tasks. This will be NO until they are performed. Tasks will not run until 'resumeAllTasks' is ran initially
+ */
+@property (nonatomic, assign, readonly) BOOL isInitialized;
+
+- (void) waitForInitializationWithCompletion:(dispatch_block_t)completion;
+
+/**
  @discussion Manually trigger refresh of sources and bundles.
  */
 - (void) refresh;

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -9,7 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "ZincGlobals.h"
 
-#define kZincRepoDefaultNetworkOperationCount (5)
+#define kZincRepoDefaultObjectDownloadCount (5)
+#define kZincRepoDefaultNetworkOperationCount (kZincRepoDefaultObjectDownloadCount*2)
 #define kZincRepoDefaultAutoRefreshInterval (120)
 #define kZincRepoDefaultCacheCount (20)
 
@@ -26,6 +27,8 @@ static NSString* ZincBundleStateName[] = {
     @"Available",
     @"Deleting",
 };
+
+extern ZincBundleState ZincBundleStateFromName(NSString* name);
 
 // -- Bundle Notifications
 extern NSString* const ZincRepoBundleStatusChangeNotification;
@@ -145,11 +148,6 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
  @discussion Perform cleanup tasks. Runs automatically at repo initialization, but can be queued manually as well.
  */
 - (void)cleanWithCompletion:(dispatch_block_t)completion;
-
-/**
- @discussion Older versions of Zinc used symlinks for some import tasks. These have been removed in current version. Enable this to clean up symlinked files.
- */
-@property (assign) BOOL shouldCleanSymlinks;
        
 @end
 

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -80,7 +80,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
         return ZincBundleStateDeleting;
     }
     
-    assert(NO);
+    NSCAssert(NO, @"unknown bundle state name: %@", name);
     return -1;
 }
 

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -275,6 +275,18 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
     }
 }
 
+- (void) setIsInitialized:(BOOL)isInitialized
+{
+    if (isInitialized) {
+        // no longer need to hold onto the initialization queue
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.initializationQueue = nil;
+        });
+    }
+    
+    _isInitialized = isInitialized;
+}
+
 - (void) setIndex:(ZincRepoIndex *)index
 {
     [_index autorelease];

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -218,7 +218,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
     self = [super init];
     if (self) {
         self.url = fileURL;
-        self.index = [[[ZincRepoIndex alloc] initWithFormat:2] autorelease];
+        self.index = [[[ZincRepoIndex alloc] init] autorelease];
         self.networkQueue = networkQueue;
         self.queueGroup = [[[ZincOperationQueueGroup alloc] init] autorelease];
         [self.queueGroup setIsBarrierOperationForClass:[ZincGarbageCollectTask class]];

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -1244,6 +1244,13 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 
 - (ZincBundle*) bundleWithId:(NSString*)bundleId
 {
+    if (!self.isInitialized) {
+        @throw [NSException
+                exceptionWithName:NSInternalInconsistencyException
+                reason:[NSString stringWithFormat:@"repo not initialized"]
+                userInfo:nil];
+    }
+
     NSString* distro = [self.index trackedDistributionForBundleId:bundleId];
     ZincVersion version = [self versionForBundleId:bundleId distribution:distro];
     if (version == ZincVersionInvalid) {

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -259,14 +259,11 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
     }
     
     // Queue a task ref that depends on all initialization tasks
-    ZincTaskRef* taskRef = [[[ZincTaskRef alloc] init] autorelease];
-    taskRef.completionBlock = ^{
+    NSOperation* initDoneOp = [[[NSOperation alloc] init] autorelease];
+    initDoneOp.completionBlock = ^{
         self.isInitialized = YES;
     };
-    for (NSOperation* op in self.initializationQueue.operations) {
-        [taskRef addDependency:op];
-    }
-    [self.initializationQueue addOperation:taskRef];
+    [self.initializationQueue addOperation:initDoneOp];
 }
 
 - (void) waitForInitializationWithCompletion:(dispatch_block_t)completion

--- a/Zinc/ZincRepoIndex.h
+++ b/Zinc/ZincRepoIndex.h
@@ -10,12 +10,21 @@
 #import "ZincGlobals.h"
 #import "ZincRepo.h"
 
+#define kZincRepoIndexCurrentFormat (2)
+
 @class ZincTrackingInfo;
 @class ZincExternalBundleInfo;
 
 @interface ZincRepoIndex : NSObject
 
+/**
+ @discussion Inits with current format kZincRepoIndexCurrentFormat
+ */
 - (id) init;
+- (id) initWithFormat:(NSInteger)format;
+
+@property (nonatomic, assign) NSInteger format;
++ (NSSet*) validFormats;
 
 - (void) addSourceURL:(NSURL*)url;
 - (void) removeSourceURL:(NSURL*)url;

--- a/Zinc/ZincTaskRef.h
+++ b/Zinc/ZincTaskRef.h
@@ -8,7 +8,11 @@
 
 #import "ZincOperation.h"
 
+@class ZincTask;
+
 @interface ZincTaskRef : ZincOperation
+
++ (ZincTaskRef*) taskRefForTask:(ZincTask*)task;
 
 - (BOOL) isValid;
 

--- a/Zinc/ZincTaskRef.m
+++ b/Zinc/ZincTaskRef.m
@@ -26,6 +26,13 @@
     return self;
 }
 
++ (ZincTaskRef*) taskRefForTask:(ZincTask*)task
+{
+    ZincTaskRef* ref = [[[ZincTaskRef alloc] init] autorelease];
+    [ref addDependency:task];
+    return ref;
+}
+
 - (void)dealloc
 {
     [_errors release];

--- a/ZincTests/ZincRepoIndexTests.m
+++ b/ZincTests/ZincRepoIndexTests.m
@@ -121,7 +121,44 @@
     ZincRepoIndex* i1 = [[[ZincRepoIndex alloc] init] autorelease];
     ZincTrackingInfo* ref = [i1 trackingInfoForBundleId:@"foo.bundle"];
     STAssertNil(ref, @"tracking ref should be nil");
+}
+
+- (void) testValidFormat
+{
+    ZincRepoIndex* i1 = [[[ZincRepoIndex alloc] init] autorelease];
+    STAssertNoThrow(i1.format = 1, @"should not throw");
+    STAssertEquals(i1.format, 1, @"should be 1");
+}
+
+- (void) testInvalidFormat
+{
+    ZincRepoIndex* i1 = [[[ZincRepoIndex alloc] init] autorelease];
+    STAssertThrows(i1.format = 0, @"should throw");
+}
+
+- (void) testDictionaryFormat1
+{
     
+}
+
+- (void) testDictionaryFormat2
+{
+    ZincRepoIndex* i1 = [[[ZincRepoIndex alloc] initWithFormat:2] autorelease];
+    NSString* bundleID = @"com.foo.pants";
+    ZincVersion version = 5;
+    NSURL* bundleRes = [NSURL zincResourceForBundleWithId:bundleID version:version];
+    [i1 setState:ZincBundleStateAvailable forBundle:bundleRes];
+    
+    NSDictionary* d = [i1 dictionaryRepresentation];
+    NSDictionary* d_versions = d[@"bundles"][bundleID][@"versions"];
+    
+    id versionVal = d_versions[[[NSNumber numberWithInteger:version] stringValue]];
+    
+    STAssertEqualObjects(versionVal, ZincBundleStateName[ZincBundleStateAvailable], @"should be equal");
+    
+    
+    NSLog(@"d");
+
 }
 
 @end


### PR DESCRIPTION
Cleaning symlinks was kludgy. I realized it could be handled more cleanly if we treated it as migrating from repo format 1 to repo format 2.
- Created format 2 of repo index (repo.json). Only difference is that the bundle state is stored as a human-readable string instead of an int ("Available" instead of "2')
- Added support for "barrier" operations in ZincOperationQueue group, inspired by libdispatch. Barrier operations runs exclusively. This allowed me to handle the special cases for GarbageCollect, BundleDelete and now CleanSymlinks more cleanly.
- Removed symlink cleaning from ZincGarbageCollect tasks and moved it into ZincCleanLegacySymlinks task. This task only runs if it reads a repo format of 1. When it finishes, it changes the repo format to 2 (current).
- Unified events for maintenance tasks
- (semi-unrelated) Increased to default download count to 5, and the network operations to twice the object download count
## TODO
- [x] Provide a way to wait for or be notified of completion of migration tasks
- [x] Consider removing "auto_update" flag in bundle tracking info
