### PR TITLE
Revamping child tasks & operations

### DIFF
--- a/Zinc/ZincArchiveDownloadTask.m
+++ b/Zinc/ZincArchiveDownloadTask.m
@@ -81,7 +81,7 @@
         [self addEvent:[ZincAchiveExtractBeginEvent archiveExtractBeginEventForResource:self.resource]];
         
         ZincArchiveExtractOperation* extractOp = [[[ZincArchiveExtractOperation alloc] initWithZincRepo:self.repo archivePath:downloadPath] autorelease];
-        [self addOperation:extractOp];
+        [self queueChildOperation:extractOp];
         
         [extractOp waitUntilFinished];
         if (self.isCancelled) return;

--- a/Zinc/ZincBundleRemoteCloneTask.m
+++ b/Zinc/ZincBundleRemoteCloneTask.m
@@ -72,7 +72,7 @@
     if (![self.repo hasManifestForBundleIdentifier:self.bundleId version:self.version]) {
         NSURL* manifestRes = [NSURL zincResourceForManifestWithId:self.bundleId version:self.version];
         ZincTaskDescriptor* taskDesc = [ZincManifestDownloadTask taskDescriptorForResource:manifestRes];
-        manifestDownloadTask = [self queueSubtaskForDescriptor:taskDesc];
+        manifestDownloadTask = [self queueChildTaskForDescriptor:taskDesc];
     }
     
     if (manifestDownloadTask != nil) {
@@ -141,7 +141,7 @@
             
             NSURL* bundleRes = [NSURL zincResourceForArchiveWithId:self.bundleId version:self.version];
             ZincTaskDescriptor* archiveTaskDesc = [ZincArchiveDownloadTask taskDescriptorForResource:bundleRes];
-            ZincTask* archiveOp = [self queueSubtaskForDescriptor:archiveTaskDesc input:[self getTrackedFlavor]];
+            ZincTask* archiveOp = [self queueChildTaskForDescriptor:archiveTaskDesc input:[self getTrackedFlavor]];
             
             [archiveOp waitUntilFinished];
             if (self.isCancelled) return NO;
@@ -164,7 +164,7 @@
                 NSURL* fileRes = [NSURL zincResourceForObjectWithSHA:sha inCatalogId:catalogId];
                 ZincTaskDescriptor* fileTaskDesc = [ZincObjectDownloadTask taskDescriptorForResource:fileRes];
                 
-                ZincTask* fileOp = [self queueSubtaskForDescriptor:fileTaskDesc input:formats];
+                ZincTask* fileOp = [self queueChildTaskForDescriptor:fileTaskDesc input:formats];
                 if (fileOp != nil) {
                     // can be nil if cancelled
                     [fileOps addObject:fileOp];

--- a/Zinc/ZincDownloadTask+Private.h
+++ b/Zinc/ZincDownloadTask+Private.h
@@ -15,8 +15,7 @@
 @property (readwrite) NSInteger bytesRead;
 @property (readwrite) NSInteger totalBytesToRead;
 
-@property (retain, readwrite) ZincHTTPRequestOperation* httpRequestOperation;
-
+@property (nonatomic, retain, readwrite) ZincHTTPRequestOperation* httpRequestOperation;
 
 - (void) queueOperationForRequest:(NSURLRequest *)request
                      outputStream:(NSOutputStream *)outputStream

--- a/Zinc/ZincDownloadTask.m
+++ b/Zinc/ZincDownloadTask.m
@@ -94,12 +94,6 @@
     self.totalBytesToRead = totalBytes;
 }
 
-- (void) setQueuePriority:(NSOperationQueuePriority)p
-{
-    [super setQueuePriority:p];
-    [self.httpRequestOperation setQueuePriority:p];
-}
-
 - (void)dealloc
 {
     [_context release];

--- a/Zinc/ZincDownloadTask.m
+++ b/Zinc/ZincDownloadTask.m
@@ -48,7 +48,7 @@
     
     self.httpRequestOperation = requestOp;
     
-    [self addOperation:requestOp];
+    [self queueChildOperation:requestOp];
 }
 
 - (void)addProgressTrackingIfNeeded
@@ -92,6 +92,12 @@
 {
     self.bytesRead = currentBytes;
     self.totalBytesToRead = totalBytes;
+}
+
+- (void) setQueuePriority:(NSOperationQueuePriority)p
+{
+    [super setQueuePriority:p];
+    [self.httpRequestOperation setQueuePriority:p];
 }
 
 - (void)dealloc

--- a/Zinc/ZincSourceUpdateTask.m
+++ b/Zinc/ZincSourceUpdateTask.m
@@ -52,7 +52,7 @@
     
     NSURLRequest* request = [self.sourceURL urlRequestForCatalogIndex];
     ZincHTTPRequestOperation* requestOp = [[[ZincHTTPRequestOperation alloc] initWithRequest:request] autorelease];
-    [self addOperation:requestOp];
+    [self queueChildOperation:requestOp];
     
     [requestOp waitUntilFinished];
     if (self.isCancelled) return;
@@ -85,7 +85,7 @@
     NSURL* catalogRes = [NSURL zincResourceForCatalogWithId:catalog.identifier];
     ZincTaskDescriptor* taskDesc = [ZincCatalogUpdateTask taskDescriptorForResource:catalogRes];
     
-    ZincTask* catalogTask = [self queueSubtaskForDescriptor:taskDesc input:catalog];
+    ZincTask* catalogTask = [self queueChildTaskForDescriptor:taskDesc input:catalog];
     
     [catalogTask waitUntilFinished];
     if (self.isCancelled) return;

--- a/Zinc/ZincTask+Private.h
+++ b/Zinc/ZincTask+Private.h
@@ -16,11 +16,11 @@
 - (id) initWithRepo:(ZincRepo*)repo resourceDescriptor:(NSURL*)resource input:(id)input;
 - (id) initWithRepo:(ZincRepo*)repo resourceDescriptor:(NSURL*)resource;
 
-- (ZincTask*) queueSubtaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor;
-- (ZincTask*) queueSubtaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor input:(id)input;
+- (ZincTask*) queueChildTaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor;
+- (ZincTask*) queueChildTaskForDescriptor:(ZincTaskDescriptor*)taskDescriptor input:(id)input;
 
 /* Currently for network ops ONLY. Consider refactoring to clean up the API */
-- (void) addOperation:(NSOperation*)operation;
+- (void) queueChildOperation:(NSOperation*)operation;
 
 /* just the events logged on this task */
 @property (readonly) NSArray* events;

--- a/Zinc/ZincTask.h
+++ b/Zinc/ZincTask.h
@@ -26,12 +26,24 @@
 
 @property (readonly, retain) NSString* title;
 
-@property (readonly) NSArray* subtasks;
+/**
+ @discussion All child operations queued by this Task.
+ */
+@property (readonly) NSArray* childOperations;
 
-/* all events including events from subtasks */
+/**
+ @discussion All child operations queued by this Task that are also ZincTasks
+ */
+@property (readonly) NSArray* childTasks;
+
+/**
+ @discussion all events including events from child tasks 
+ */
 - (NSArray*) allEvents;
 
-/* all errors that occurred including errors from subtasks */
+/**
+ @discussion all errors that occurred including errors from child tasks
+ */
 - (NSArray*) allErrors;
 
 @end


### PR DESCRIPTION
Dependening on [NSOperation dependencies] to retrieve child operations
(previously called subtasks) wasn't correct. There could be other dependencies,
such as barrier operations that we not technically child tasks.
