### PR TITLE
Fixing possible deadlock with operation cancel

### DIFF
--- a/Zinc/ZincOperation.m
+++ b/Zinc/ZincOperation.m
@@ -58,13 +58,4 @@ double _defaultThreadPriority = kZincOperationInitialDefaultThreadPriority;
     return ZincProgressCalculate(self);
 }
 
-- (void) cancel
-{
-    @synchronized(self) {
-        [super cancel];
-        [self.dependencies makeObjectsPerformSelector:@selector(cancel)];
-    }
-}
-
-
 @end

--- a/Zinc/ZincTask.m
+++ b/Zinc/ZincTask.m
@@ -233,4 +233,13 @@ typedef id ZincBackgroundTaskIdentifier;
 }
 #endif
 
+- (void) cancel
+{
+    @synchronized(self.myChildOperations) {
+        [self.myChildOperations makeObjectsPerformSelector:@selector(cancel)];
+    }
+    
+    [super cancel];
+}
+
 @end


### PR DESCRIPTION
Only cancelling explicit child operations, not all dependencies.
