### PR TITLE
Set refresh timer on the main thread

### DIFF
--- a/Zinc/ZincActivityMonitor.m
+++ b/Zinc/ZincActivityMonitor.m
@@ -49,11 +49,13 @@ NSString* const ZincActivityMonitorRefreshedNotification = @"ZincActivityMonitor
     
     if (!self.isMonitoring) return;
     
-    self.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:self.refreshInterval
-                                                         target:self
-                                                       selector:@selector(update)
-                                                       userInfo:nil
-                                                        repeats:YES];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:self.refreshInterval
+                                                             target:self
+                                                           selector:@selector(update)
+                                                           userInfo:nil
+                                                            repeats:YES];
+    });
 }
 
 - (void)stopRefreshTimer


### PR DESCRIPTION
In `ZincActivityMonitor.m`, if the `refreshTimer` is not set on the main thread, it won't fire. I found this out the hard way.

I wrapped it in a dispatch_async block, but feel free to use a better solution.
