### PR TITLE
Expanding "initializationQueue" to "internalQueue". 

### DIFF
--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -99,7 +99,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 // runtime state
 @property (nonatomic, retain) NSMutableDictionary* sourcesByCatalog;
 @property (nonatomic, retain) NSOperationQueue* networkQueue;
-@property (nonatomic, retain) ZincOperationQueueGroup* queueGroup;
+@property (nonatomic, retain) ZincOperationQueueGroup* taskQueueGroup;
 @property (nonatomic, retain) NSTimer* refreshTimer;
 @property (nonatomic, retain) NSMutableDictionary* loadedBundles;
 @property (nonatomic, retain) NSCache* cache;
@@ -108,7 +108,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 @property (nonatomic, retain, readwrite) ZincDownloadPolicy* downloadPolicy;
 @property (nonatomic, retain) ZincKSReachability* reachability;
 @property (nonatomic, retain) NSMutableDictionary* localFilesBySHA;
-@property (nonatomic, retain) NSOperationQueue* initializationQueue;
+@property (nonatomic, retain) NSOperationQueue* internalQueue;
 @property (nonatomic, retain) ZincCompleteInitializationTask* completeInitializationTask;
 @property (nonatomic, assign, readwrite) BOOL isInitialized;
 
@@ -145,20 +145,6 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 
 
 @implementation ZincRepo
-
-@synthesize delegate = _delegate;
-@synthesize index = _index;
-@synthesize url = _url;
-@synthesize networkQueue = _networkQueue;
-@synthesize sourcesByCatalog = _sourcesByCatalog;
-@synthesize fileManager = _fileManager;
-@synthesize cache = _cache;
-@synthesize autoRefreshInterval = _refreshInterval;
-@synthesize refreshTimer = _refreshTimer;
-@synthesize loadedBundles = _loadedBundles;
-@synthesize myTasks = _myTasks;
-@synthesize queueGroup = _queueGroup;
-@synthesize executeTasksInBackgroundEnabled = _shouldExecuteTasksInBackground;
 
 + (ZincRepo*) repoWithURL:(NSURL*)fileURL error:(NSError**)outError
 {
@@ -200,7 +186,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
         repo.index = index;
     }
     
-    [repo.queueGroup setSuspended:YES];
+    [repo.taskQueueGroup setSuspended:YES];
     
     if (![repo queueInitializationTasks]) {
         repo.isInitialized = YES;
@@ -228,18 +214,19 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
         self.url = fileURL;
         self.index = [[[ZincRepoIndex alloc] init] autorelease];
         self.networkQueue = networkQueue;
-        self.queueGroup = [[[ZincOperationQueueGroup alloc] init] autorelease];
-        [self.queueGroup setIsBarrierOperationForClass:[ZincGarbageCollectTask class]];
-        [self.queueGroup setIsBarrierOperationForClass:[ZincBundleDeleteTask class]];
-        [self.queueGroup setMaxConcurrentOperationCount:2 forClass:[ZincBundleRemoteCloneTask class]];
-        [self.queueGroup setMaxConcurrentOperationCount:1 forClass:[ZincCatalogUpdateTask class]];
-        [self.queueGroup setMaxConcurrentOperationCount:kZincRepoDefaultObjectDownloadCount forClass:[ZincObjectDownloadTask class]];
-        [self.queueGroup setMaxConcurrentOperationCount:1 forClass:[ZincSourceUpdateTask class]];
-        [self.queueGroup setMaxConcurrentOperationCount:1 forClass:[ZincArchiveExtractOperation class]];
+        self.internalQueue = [[[NSOperationQueue alloc] init] autorelease];
+        self.taskQueueGroup = [[[ZincOperationQueueGroup alloc] init] autorelease];
+        [self.taskQueueGroup setIsBarrierOperationForClass:[ZincGarbageCollectTask class]];
+        [self.taskQueueGroup setIsBarrierOperationForClass:[ZincBundleDeleteTask class]];
+        [self.taskQueueGroup setMaxConcurrentOperationCount:2 forClass:[ZincBundleRemoteCloneTask class]];
+        [self.taskQueueGroup setMaxConcurrentOperationCount:1 forClass:[ZincCatalogUpdateTask class]];
+        [self.taskQueueGroup setMaxConcurrentOperationCount:kZincRepoDefaultObjectDownloadCount forClass:[ZincObjectDownloadTask class]];
+        [self.taskQueueGroup setMaxConcurrentOperationCount:1 forClass:[ZincSourceUpdateTask class]];
+        [self.taskQueueGroup setMaxConcurrentOperationCount:1 forClass:[ZincArchiveExtractOperation class]];
         self.fileManager = [[[NSFileManager alloc] init] autorelease];
         self.cache = [[[NSCache alloc] init] autorelease];
         self.cache.countLimit = kZincRepoDefaultCacheCount;
-        _refreshInterval = kZincRepoDefaultAutoRefreshInterval;
+        _autoRefreshInterval = kZincRepoDefaultAutoRefreshInterval;
         self.sourcesByCatalog = [NSMutableDictionary dictionary];
         self.loadedBundles = [[[NSMutableDictionary alloc] init] autorelease];
         self.myTasks = [NSMutableArray array];
@@ -247,8 +234,6 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
         self.downloadPolicy = [[[ZincDownloadPolicy alloc] init] autorelease];
         self.reachability = reachability;
         self.localFilesBySHA = [NSMutableDictionary dictionary];
-        self.initializationQueue = [[[NSOperationQueue alloc] init] autorelease];
-        [self.initializationQueue setMaxConcurrentOperationCount:1];
     }
     return self;
 }
@@ -290,7 +275,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
     @synchronized(self) {
         if (self.isInitialized || self.completeInitializationTask == nil) return nil;
         ZincTaskRef* taskRef = [ZincTaskRef taskRefForTask:self.completeInitializationTask];
-        [self.initializationQueue addOperation:taskRef];
+        [self.internalQueue addOperation:taskRef];
         return taskRef;
     }
 }
@@ -307,7 +292,6 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
             // no longer need to hold onto the initialization queue or task
             __block typeof(self) blockself = self;
             dispatch_async(dispatch_get_main_queue(), ^{
-                blockself.initializationQueue = nil;
                 blockself.completeInitializationTask = nil;
             });
         }
@@ -322,7 +306,7 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 
 - (void) setAutoRefreshInterval:(NSTimeInterval)refreshInterval
 {
-    _refreshInterval = refreshInterval;
+    _autoRefreshInterval = refreshInterval;
     [self restartRefreshTimer];
 }
 
@@ -463,12 +447,12 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
     [_index release];
     // TODO: stop operations?
     [_networkQueue release];
-    [_queueGroup release];
+    [_internalQueue release];
+    [_taskQueueGroup release];
     [_sourcesByCatalog release];
     [_cache release];
     [_loadedBundles release];
     [_myTasks release];
-    [_initializationQueue release];
     [_completeInitializationTask release];
     [super dealloc];
 }
@@ -607,10 +591,12 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 {
     if ([operation isKindOfClass:[ZincURLConnectionOperation class]]) {
         [self.networkQueue addOperation:operation];
-    } else if ([operation isKindOfClass:[ZincInitializationTask class]]) {
-        [self.initializationQueue addOperation:operation];
+    } else if ([operation isKindOfClass:[ZincInitializationTask class]] ||
+               [operation isKindOfClass:[ZincRepoIndexUpdateTask class]] ||
+               [operation isKindOfClass:[ZincTaskRef class]]) {
+        [self.internalQueue addOperation:operation];
     } else {
-        [self.queueGroup addOperation:operation];
+        [self.taskQueueGroup addOperation:operation];
     }
 }
 
@@ -1302,18 +1288,18 @@ ZincBundleState ZincBundleStateFromName(NSString* name)
 - (void) suspendAllTasks
 {
     [self stopRefreshTimer];
-    [self.queueGroup setSuspended:YES];
+    [self.taskQueueGroup setSuspended:YES];
 }
 
 - (void) suspendAllTasksAndWaitExecutingTasksToComplete
 {
     [self suspendAllTasks];
-    [self.queueGroup suspendAndWaitForExecutingOperationsToComplete];
+    [self.taskQueueGroup suspendAndWaitForExecutingOperationsToComplete];
 }
 
 - (void) resumeAllTasks
 {
-    [self.queueGroup setSuspended:NO];
+    [self.taskQueueGroup setSuspended:NO];
     [self restartRefreshTimer];
 }
 


### PR DESCRIPTION
Now TaskRef and RepoIndexUpdate operations run in this queue.

This is to prevent some kinds of deadlocks occurring when the taskQueue is suspended. Now "internal" operations can still run.
