### PR TITLE
Going back to private copy of AFNetworking operations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Dependencies/External/AFNetworking"]
-	path = Dependencies/External/AFNetworking
-	url = git@github.com:mindsnacks/AFNetworking.git
 [submodule "Dependencies/External/KSReachability"]
 	path = Dependencies/External/KSReachability
 	url = git@github.com:mindsnacks/KSReachability.git

--- a/Zinc-ObjC.xcodeproj/project.pbxproj
+++ b/Zinc-ObjC.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		B30B763C14B75750004E6587 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B30B763B14B75750004E6587 /* libz.dylib */; };
 		B311841F16F7CBAF00D13BD0 /* ErrorStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B311841E16F7CBAF00D13BD0 /* ErrorStateTests.m */; };
 		B317E4F215C9F8AF00DE9D73 /* ZincJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = B317E4F015C9F8AF00DE9D73 /* ZincJSONSerialization.m */; };
-		B31DE37616CAFED9004F88ED /* libAFNetworking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE37516CAFED9004F88ED /* libAFNetworking.a */; };
 		B31DE37816CAFF15004F88ED /* libKSReachability.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE37716CAFF15004F88ED /* libKSReachability.a */; };
 		B31DE38616CAFFD3004F88ED /* GHUnitIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE38516CAFFD3004F88ED /* GHUnitIOS.framework */; };
 		B31DE38716CB0030004F88ED /* NSFileManager+ZincTar.m in Sources */ = {isa = PBXBuildFile; fileRef = B31DE37E16CAFF58004F88ED /* NSFileManager+ZincTar.m */; };
@@ -36,7 +35,6 @@
 		B31DE3B616CCBACA004F88ED /* ZincOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B347EBDE15C3593500FA0649 /* ZincOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B31DE3FD16CD822A004F88ED /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE3FC16CD822A004F88ED /* libOCMock.a */; };
 		B31DE40216CD8275004F88ED /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B308D67616CA221F008A1237 /* MobileCoreServices.framework */; };
-		B31DE40316CD8283004F88ED /* libAFNetworking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE37516CAFED9004F88ED /* libAFNetworking.a */; };
 		B31DE40416CD8283004F88ED /* libKSReachability.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B31DE37716CAFF15004F88ED /* libKSReachability.a */; };
 		B3215E2314BE5AF800FC7FA7 /* ZincTaskDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = B3215E2114BE5AF800FC7FA7 /* ZincTaskDescriptor.m */; };
 		B3215E2714BE600E00FC7FA7 /* ZincResource.m in Sources */ = {isa = PBXBuildFile; fileRef = B3215E2514BE600E00FC7FA7 /* ZincResource.m */; };
@@ -153,6 +151,10 @@
 		B3E7510E1705027E00D8A989 /* NSOperation+Zinc.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7510C1705027E00D8A989 /* NSOperation+Zinc.m */; };
 		B3EACD8714BD4907004D90EC /* ZincGarbageCollectTask.m in Sources */ = {isa = PBXBuildFile; fileRef = B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */; };
 		B3F14A5E15BB840900F7E22E /* ZincTaskActions.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */; };
+		B3F201E317722C4600F4A01E /* ZincHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F201E117722C4600F4A01E /* ZincHTTPRequestOperation.h */; };
+		B3F201E417722C4600F4A01E /* ZincHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F201E217722C4600F4A01E /* ZincHTTPRequestOperation.m */; };
+		B3F201E717722C8E00F4A01E /* ZincURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F201E517722C8E00F4A01E /* ZincURLConnectionOperation.h */; };
+		B3F201E817722C8E00F4A01E /* ZincURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F201E617722C8E00F4A01E /* ZincURLConnectionOperation.m */; };
 		B3F8AF77148EFCDF00CB92B5 /* ZincRepo.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */; };
 /* End PBXBuildFile section */
 
@@ -187,7 +189,6 @@
 		B311841E16F7CBAF00D13BD0 /* ErrorStateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ErrorStateTests.m; sourceTree = "<group>"; };
 		B317E4EF15C9F8AF00DE9D73 /* ZincJSONSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincJSONSerialization.h; sourceTree = "<group>"; };
 		B317E4F015C9F8AF00DE9D73 /* ZincJSONSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincJSONSerialization.m; sourceTree = "<group>"; };
-		B31DE37516CAFED9004F88ED /* libAFNetworking.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libAFNetworking.a; path = "Dependencies/External/AFNetworking/build/Release-iphoneos/libAFNetworking.a"; sourceTree = "<group>"; };
 		B31DE37716CAFF15004F88ED /* libKSReachability.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libKSReachability.a; path = "Dependencies/External/KSReachability/build/Release-iphoneos/libKSReachability.a"; sourceTree = "<group>"; };
 		B31DE37916CAFF4A004F88ED /* AMError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AMError.h; path = Dependencies/Internal/AMFoundation/AMError.h; sourceTree = SOURCE_ROOT; };
 		B31DE37A16CAFF4A004F88ED /* AMFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AMFoundation.h; path = Dependencies/Internal/AMFoundation/AMFoundation.h; sourceTree = SOURCE_ROOT; };
@@ -389,6 +390,10 @@
 		B3EACD8514BD4906004D90EC /* ZincGarbageCollectTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ZincGarbageCollectTask.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B3F14A5B15BB840900F7E22E /* ZincTaskActions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincTaskActions.h; sourceTree = "<group>"; };
 		B3F14A5C15BB840900F7E22E /* ZincTaskActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincTaskActions.m; sourceTree = "<group>"; };
+		B3F201E117722C4600F4A01E /* ZincHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincHTTPRequestOperation.h; sourceTree = "<group>"; };
+		B3F201E217722C4600F4A01E /* ZincHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincHTTPRequestOperation.m; sourceTree = "<group>"; };
+		B3F201E517722C8E00F4A01E /* ZincURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincURLConnectionOperation.h; sourceTree = "<group>"; };
+		B3F201E617722C8E00F4A01E /* ZincURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZincURLConnectionOperation.m; sourceTree = "<group>"; };
 		B3F8AF74148EFCDF00CB92B5 /* ZincRepo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZincRepo.h; sourceTree = "<group>"; };
 		B3F8AF75148EFCDF00CB92B5 /* ZincRepo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ZincRepo.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		D00356D8153760220021627E /* ZincEvent+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZincEvent+Private.h"; sourceTree = "<group>"; };
@@ -400,7 +405,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B31DE37816CAFF15004F88ED /* libKSReachability.a in Frameworks */,
-				B31DE37616CAFED9004F88ED /* libAFNetworking.a in Frameworks */,
 				B308D67716CA221F008A1237 /* MobileCoreServices.framework in Frameworks */,
 				B33A362B1698FB4D007F0A57 /* libz.dylib in Frameworks */,
 				B33A362A1698FB3F007F0A57 /* SystemConfiguration.framework in Frameworks */,
@@ -426,7 +430,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B31DE40216CD8275004F88ED /* MobileCoreServices.framework in Frameworks */,
-				B31DE40316CD8283004F88ED /* libAFNetworking.a in Frameworks */,
 				B31DE40416CD8283004F88ED /* libKSReachability.a in Frameworks */,
 				B31DE3FD16CD822A004F88ED /* libOCMock.a in Frameworks */,
 				B3B7BA96157D436C00613B8B /* CFNetwork.framework in Frameworks */,
@@ -702,7 +705,6 @@
 				B387430A1489B830004B227B /* Foundation.framework */,
 				B387430C1489B830004B227B /* CoreGraphics.framework */,
 				B340F94A148D514600206F86 /* SenTestingKit.framework */,
-				B31DE37516CAFED9004F88ED /* libAFNetworking.a */,
 				B31DE37716CAFF15004F88ED /* libKSReachability.a */,
 			);
 			name = Frameworks;
@@ -913,10 +915,22 @@
 				B33AEF9316A6321C0000B6C5 /* ZincExternalBundleInfo.h */,
 				B33AEF9416A6321C0000B6C5 /* ZincExternalBundleInfo.m */,
 				B33AF01116A641700000B6C5 /* ZincBundleTrackingRequest.m */,
+				B3F201E917722C9700F4A01E /* Networking */,
 				B3E46B5114C3DDB900030349 /* Tasks */,
 				B3CAB5F515FC3644008502AC /* Activity */,
 			);
 			name = Main;
+			sourceTree = "<group>";
+		};
+		B3F201E917722C9700F4A01E /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				B3F201E117722C4600F4A01E /* ZincHTTPRequestOperation.h */,
+				B3F201E217722C4600F4A01E /* ZincHTTPRequestOperation.m */,
+				B3F201E517722C8E00F4A01E /* ZincURLConnectionOperation.h */,
+				B3F201E617722C8E00F4A01E /* ZincURLConnectionOperation.m */,
+			);
+			name = Networking;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -930,6 +944,7 @@
 				B31DE3A616CCBACA004F88ED /* ZincGlobals.h in Headers */,
 				B31DE3A716CCBACA004F88ED /* ZincErrors.h in Headers */,
 				B31DE3A816CCBACA004F88ED /* ZincRepo.h in Headers */,
+				B3F201E717722C8E00F4A01E /* ZincURLConnectionOperation.h in Headers */,
 				B31DE3A916CCBACA004F88ED /* ZincBundle.h in Headers */,
 				B31DE3AA16CCBACA004F88ED /* ZincResource.h in Headers */,
 				B31DE3AB16CCBACA004F88ED /* ZincBundleTrackingRequest.h in Headers */,
@@ -949,6 +964,7 @@
 				B3E7510D1705027E00D8A989 /* NSOperation+Zinc.h in Headers */,
 				B3443A381742A965000920B8 /* ZincRepoBundleManager.h in Headers */,
 				B3C512B2175E57FB00E5A93B /* ZincRepoTaskManager.h in Headers */,
+				B3F201E317722C4600F4A01E /* ZincHTTPRequestOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1147,6 +1163,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3F201E817722C8E00F4A01E /* ZincURLConnectionOperation.m in Sources */,
 				B340F996148D543B00206F86 /* ZincBundle.m in Sources */,
 				B340FA05148D608D00206F86 /* NSFileManager+Zinc.m in Sources */,
 				B3549DF0148DB80900DD63D1 /* ZincManifest.m in Sources */,
@@ -1179,6 +1196,7 @@
 				B3F14A5E15BB840900F7E22E /* ZincTaskActions.m in Sources */,
 				B347EBE115C3593500FA0649 /* ZincOperation.m in Sources */,
 				B3BFF9E115C62363005A879E /* ZincTaskRef.m in Sources */,
+				B3F201E417722C4600F4A01E /* ZincHTTPRequestOperation.m in Sources */,
 				B317E4F215C9F8AF00DE9D73 /* ZincJSONSerialization.m in Sources */,
 				B3CC221F15DB7D6E00B2D3DB /* ZincDownloadPolicy.m in Sources */,
 				B32BE82315EEF92900E6EBFA /* NSError+Zinc.m in Sources */,

--- a/Zinc-ObjC.xcworkspace/contents.xcworkspacedata
+++ b/Zinc-ObjC.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "group:Zinc-ObjC.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Dependencies/External/AFNetworking/AFNetworking.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Dependencies/External/KSReachability/KSReachability.xcodeproj">
    </FileRef>
    <FileRef

--- a/Zinc-ObjC.xcworkspace/xcshareddata/xcschemes/Zinc Functional Tests.xcscheme
+++ b/Zinc-ObjC.xcworkspace/xcshareddata/xcschemes/Zinc Functional Tests.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B32E313A16C9C4390032E7E8"
-               BuildableName = "libAFNetworking.a"
-               BlueprintName = "AFNetworking"
-               ReferencedContainer = "container:Dependencies/External/AFNetworking/AFNetworking.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "B32E31F416C9DC410032E7E8"
                BuildableName = "libKSReachability.a"
                BlueprintName = "KSReachability"

--- a/Zinc-ObjC.xcworkspace/xcshareddata/xcschemes/Zinc.xcscheme
+++ b/Zinc-ObjC.xcworkspace/xcshareddata/xcschemes/Zinc.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B32E313A16C9C4390032E7E8"
-               BuildableName = "libAFNetworking.a"
-               BlueprintName = "AFNetworking"
-               ReferencedContainer = "container:Dependencies/External/AFNetworking/AFNetworking.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "B32E31F416C9DC410032E7E8"
                BuildableName = "libKSReachability.a"
                BlueprintName = "KSReachability"

--- a/Zinc/Zinc-Prefix.pch
+++ b/Zinc/Zinc-Prefix.pch
@@ -6,6 +6,5 @@
     #import <Foundation/Foundation.h>
     #import <MobileCoreServices/MobileCoreServices.h>
     #import <SystemConfiguration/SystemConfiguration.h>
-    #import <AFNetworking/AFNetworking.h>
     #import "AMFoundation.h"
 #endif

--- a/Zinc/ZincDownloadTask+Private.h
+++ b/Zinc/ZincDownloadTask+Private.h
@@ -8,14 +8,14 @@
 
 #import "ZincDownloadTask.h"
 
-@class AFHTTPRequestOperation;
+@class ZincHTTPRequestOperation;
 
 @interface ZincDownloadTask ()
 
 @property (readwrite) NSInteger bytesRead;
 @property (readwrite) NSInteger totalBytesToRead;
 
-@property (nonatomic, strong, readwrite) AFHTTPRequestOperation* httpRequestOperation;
+@property (nonatomic, strong, readwrite) ZincHTTPRequestOperation* httpRequestOperation;
 
 - (void) queueOperationForRequest:(NSURLRequest *)request
                      outputStream:(NSOutputStream *)outputStream

--- a/Zinc/ZincDownloadTask.m
+++ b/Zinc/ZincDownloadTask.m
@@ -12,6 +12,7 @@
 #import "ZincEvent.h"
 #import "ZincTaskActions.h"
 #import "ZincRepo.h"
+#import "ZincHTTPRequestOperation.h"
 
 // TODO: break this dependency?
 #import "ZincRepo+Private.h"
@@ -33,7 +34,7 @@
 {
     NSAssert(self.httpRequestOperation == nil || [self.httpRequestOperation isFinished], @"operation already enqueued");
     
-    AFHTTPRequestOperation* requestOp = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    ZincHTTPRequestOperation* requestOp = [[ZincHTTPRequestOperation alloc] initWithRequest:request];
     
     if (outputStream != nil) {
         requestOp.outputStream = outputStream;
@@ -63,7 +64,7 @@
     __block NSTimeInterval lastTimeEventSentDate = 0;
     __weak typeof(self) weakself = self;
     
-    [self.httpRequestOperation setDownloadProgressBlock:^(NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
+    [self.httpRequestOperation setDownloadProgressBlock:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
 
         __weak typeof(weakself) strongself = weakself;
 

--- a/Zinc/ZincHTTPRequestOperation+ZincContextInfo.h
+++ b/Zinc/ZincHTTPRequestOperation+ZincContextInfo.h
@@ -6,9 +6,9 @@
 //  Copyright (c) 2013 MindSnacks. All rights reserved.
 //
 
-#import <AFNetworking/AFNetworking.h>
+#import "ZincHTTPRequestOperation.h"
 
-@interface AFHTTPRequestOperation (ZincContextInfo)
+@interface ZincHTTPRequestOperation (ZincContextInfo)
 
 - (NSDictionary*) zinc_contextInfo;
 

--- a/Zinc/ZincHTTPRequestOperation+ZincContextInfo.m
+++ b/Zinc/ZincHTTPRequestOperation+ZincContextInfo.m
@@ -8,7 +8,7 @@
 
 #import "ZincHTTPRequestOperation+ZincContextInfo.h"
 
-@implementation AFHTTPRequestOperation (ZincContextInfo)
+@implementation ZincHTTPRequestOperation (ZincContextInfo)
 
 - (NSDictionary*) zinc_contextInfo
 {

--- a/Zinc/ZincHTTPRequestOperation.h
+++ b/Zinc/ZincHTTPRequestOperation.h
@@ -1,0 +1,133 @@
+// AFHTTPRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "ZincURLConnectionOperation.h"
+
+/**
+ `AFHTTPRequestOperation` is a subclass of `AFURLConnectionOperation` for requests using the HTTP or HTTPS protocols. It encapsulates the concept of acceptable status codes and content types, which determine the success or failure of a request.
+ */
+@interface ZincHTTPRequestOperation : ZincURLConnectionOperation
+
+///----------------------------------------------
+/// @name Getting HTTP URL Connection Information
+///----------------------------------------------
+
+/**
+ The last HTTP response received by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSHTTPURLResponse *response;
+
+///----------------------------------------------------------
+/// @name Managing And Checking For Acceptable HTTP Responses
+///----------------------------------------------------------
+
+/**
+ A Boolean value that corresponds to whether the status code of the response is within the specified set of acceptable status codes. Returns `YES` if `acceptableStatusCodes` is `nil`.
+ */
+@property (nonatomic, readonly) BOOL hasAcceptableStatusCode;
+
+/**
+ A Boolean value that corresponds to whether the MIME type of the response is among the specified set of acceptable content types. Returns `YES` if `acceptableContentTypes` is `nil`.
+ */
+@property (nonatomic, readonly) BOOL hasAcceptableContentType;
+
+/**
+ The callback dispatch queue on success. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t successCallbackQueue;
+
+/**
+ The callback dispatch queue on failure. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t failureCallbackQueue;
+
+///------------------------------------------------------------
+/// @name Managing Acceptable HTTP Status Codes & Content Types
+///------------------------------------------------------------
+
+/**
+ Returns an `NSIndexSet` object containing the ranges of acceptable HTTP status codes. When non-`nil`, the operation will set the `error` property to an error in `AFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+
+ By default, this is the range 200 to 299, inclusive.
+ */
++ (NSIndexSet *)acceptableStatusCodes;
+
+/**
+ Adds status codes to the set of acceptable HTTP status codes returned by `+acceptableStatusCodes` in subsequent calls by this class and its descendants.
+
+ @param statusCodes The status codes to be added to the set of acceptable HTTP status codes
+ */
++ (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes;
+
+/**
+ Returns an `NSSet` object containing the acceptable MIME types. When non-`nil`, the operation will set the `error` property to an error in `AFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
+
+ By default, this is `nil`.
+ */
++ (NSSet *)acceptableContentTypes;
+
+/**
+ Adds content types to the set of acceptable MIME types returned by `+acceptableContentTypes` in subsequent calls by this class and its descendants.
+
+ @param contentTypes The content types to be added to the set of acceptable MIME types
+ */
++ (void)addAcceptableContentTypes:(NSSet *)contentTypes;
+
+
+///-----------------------------------------------------
+/// @name Determining Whether A Request Can Be Processed
+///-----------------------------------------------------
+
+/**
+ A Boolean value determining whether or not the class can process the specified request. For example, `AFJSONRequestOperation` may check to make sure the content type was `application/json` or the URL path extension was `.json`.
+
+ @param urlRequest The request that is determined to be supported or not supported for this class.
+ */
++ (BOOL)canProcessRequest:(NSURLRequest *)urlRequest;
+
+///-----------------------------------------------------------
+/// @name Setting Completion Block Success / Failure Callbacks
+///-----------------------------------------------------------
+
+/**
+ Sets the `completionBlock` property with a block that executes either the specified success or failure block, depending on the state of the request on completion. If `error` returns a value, which can be caused by an unacceptable status code or content type, then `failure` is executed. Otherwise, `success` is executed.
+
+ This method should be overridden in subclasses in order to specify the response object passed into the success block.
+ 
+ @param success The block to be executed on the completion of a successful request. This block has no return value and takes two arguments: the receiver operation and the object constructed from the response data of the request.
+ @param failure The block to be executed on the completion of an unsuccessful request. This block has no return value and takes two arguments: the receiver operation and the error that occurred during the request.
+ */
+- (void)setCompletionBlockWithSuccess:(void (^)(ZincHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(ZincHTTPRequestOperation *operation, NSError *error))failure;
+
+@end
+
+///----------------
+/// @name Functions
+///----------------
+
+/**
+ Returns a set of MIME types detected in an HTTP `Accept` or `Content-Type` header.
+ */
+extern NSSet * AFContentTypesFromHTTPHeader(NSString *string);
+

--- a/Zinc/ZincHTTPRequestOperation.h
+++ b/Zinc/ZincHTTPRequestOperation.h
@@ -1,4 +1,4 @@
-// AFHTTPRequestOperation.h
+// ZincHTTPRequestOperation.h
 //
 // Copyright (c) 2011 Gowalla (http://gowalla.com/)
 //
@@ -24,7 +24,7 @@
 #import "ZincURLConnectionOperation.h"
 
 /**
- `AFHTTPRequestOperation` is a subclass of `AFURLConnectionOperation` for requests using the HTTP or HTTPS protocols. It encapsulates the concept of acceptable status codes and content types, which determine the success or failure of a request.
+ `ZincHTTPRequestOperation` is a subclass of `ZincURLConnectionOperation` for requests using the HTTP or HTTPS protocols. It encapsulates the concept of acceptable status codes and content types, which determine the success or failure of a request.
  */
 @interface ZincHTTPRequestOperation : ZincURLConnectionOperation
 
@@ -66,7 +66,7 @@
 ///------------------------------------------------------------
 
 /**
- Returns an `NSIndexSet` object containing the ranges of acceptable HTTP status codes. When non-`nil`, the operation will set the `error` property to an error in `AFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+ Returns an `NSIndexSet` object containing the ranges of acceptable HTTP status codes. When non-`nil`, the operation will set the `error` property to an error in `ZincNetworkingErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
 
  By default, this is the range 200 to 299, inclusive.
  */
@@ -80,7 +80,7 @@
 + (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes;
 
 /**
- Returns an `NSSet` object containing the acceptable MIME types. When non-`nil`, the operation will set the `error` property to an error in `AFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
+ Returns an `NSSet` object containing the acceptable MIME types. When non-`nil`, the operation will set the `error` property to an error in `ZincNetworkingErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
 
  By default, this is `nil`.
  */
@@ -99,7 +99,7 @@
 ///-----------------------------------------------------
 
 /**
- A Boolean value determining whether or not the class can process the specified request. For example, `AFJSONRequestOperation` may check to make sure the content type was `application/json` or the URL path extension was `.json`.
+ A Boolean value determining whether or not the class can process the specified request.
 
  @param urlRequest The request that is determined to be supported or not supported for this class.
  */
@@ -129,5 +129,5 @@
 /**
  Returns a set of MIME types detected in an HTTP `Accept` or `Content-Type` header.
  */
-extern NSSet * AFContentTypesFromHTTPHeader(NSString *string);
+extern NSSet * ZincContentTypesFromHTTPHeader(NSString *string);
 

--- a/Zinc/ZincHTTPRequestOperation.m
+++ b/Zinc/ZincHTTPRequestOperation.m
@@ -1,0 +1,323 @@
+// AFHTTPRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ZincHTTPRequestOperation.h"
+#import <objc/runtime.h>
+
+// Workaround for change in imp_implementationWithBlock() with Xcode 4.5
+#if defined(__IPHONE_6_0) || defined(__MAC_10_8)
+#define AF_CAST_TO_BLOCK id
+#else
+#define AF_CAST_TO_BLOCK __bridge void *
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-selector-match"
+
+NSSet * AFContentTypesFromHTTPHeader(NSString *string) {
+    if (!string) {
+        return nil;
+    }
+
+    NSArray *mediaRanges = [string componentsSeparatedByString:@","];
+    NSMutableSet *mutableContentTypes = [NSMutableSet setWithCapacity:mediaRanges.count];
+
+    [mediaRanges enumerateObjectsUsingBlock:^(NSString *mediaRange, __unused NSUInteger idx, __unused BOOL *stop) {
+        NSRange parametersRange = [mediaRange rangeOfString:@";"];
+        if (parametersRange.location != NSNotFound) {
+            mediaRange = [mediaRange substringToIndex:parametersRange.location];
+        }
+
+        mediaRange = [mediaRange stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+        if (mediaRange.length > 0) {
+            [mutableContentTypes addObject:mediaRange];
+        }
+    }];
+
+    return [NSSet setWithSet:mutableContentTypes];
+}
+
+static void AFGetMediaTypeAndSubtypeWithString(NSString *string, NSString **type, NSString **subtype) {
+    if (!string) {
+        return;
+    }
+
+    NSScanner *scanner = [NSScanner scannerWithString:string];
+    [scanner setCharactersToBeSkipped:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    [scanner scanUpToString:@"/" intoString:type];
+    [scanner scanString:@"/" intoString:nil];
+    [scanner scanUpToString:@";" intoString:subtype];
+}
+
+static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
+    NSMutableString *string = [NSMutableString string];
+
+    NSRange range = NSMakeRange([indexSet firstIndex], 1);
+    while (range.location != NSNotFound) {
+        NSUInteger nextIndex = [indexSet indexGreaterThanIndex:range.location];
+        while (nextIndex == range.location + range.length) {
+            range.length++;
+            nextIndex = [indexSet indexGreaterThanIndex:nextIndex];
+        }
+
+        if (string.length) {
+            [string appendString:@","];
+        }
+
+        if (range.length == 1) {
+            [string appendFormat:@"%lu", (long)range.location];
+        } else {
+            NSUInteger firstIndex = range.location;
+            NSUInteger lastIndex = firstIndex + range.length - 1;
+            [string appendFormat:@"%lu-%lu", (long)firstIndex, (long)lastIndex];
+        }
+
+        range.location = nextIndex;
+        range.length = 1;
+    }
+
+    return string;
+}
+
+static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL selector, id block) {
+    Method originalMethod = class_getClassMethod(klass, selector);
+    IMP implementation = imp_implementationWithBlock((AF_CAST_TO_BLOCK)block);
+    class_replaceMethod(objc_getMetaClass([NSStringFromClass(klass) UTF8String]), selector, implementation, method_getTypeEncoding(originalMethod));
+}
+
+#pragma mark -
+
+@interface ZincHTTPRequestOperation ()
+@property (readwrite, nonatomic, strong) NSURLRequest *request;
+@property (readwrite, nonatomic, strong) NSHTTPURLResponse *response;
+@property (readwrite, nonatomic, strong) NSError *HTTPError;
+@end
+
+@implementation ZincHTTPRequestOperation
+@synthesize HTTPError = _HTTPError;
+@synthesize successCallbackQueue = _successCallbackQueue;
+@synthesize failureCallbackQueue = _failureCallbackQueue;
+@dynamic request;
+@dynamic response;
+
+- (void)dealloc {
+    if (_successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+        dispatch_release(_successCallbackQueue);
+#endif
+        _successCallbackQueue = NULL;
+    }
+
+    if (_failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+        dispatch_release(_failureCallbackQueue);
+#endif
+        _failureCallbackQueue = NULL;
+    }
+}
+
+- (NSError *)error {
+    if (!self.HTTPError && self.response) {
+        if (![self hasAcceptableStatusCode] || ![self hasAcceptableContentType]) {
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+            [userInfo setValue:self.responseString forKey:NSLocalizedRecoverySuggestionErrorKey];
+            [userInfo setValue:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+            [userInfo setValue:self.request forKey:AFNetworkingOperationFailingURLRequestErrorKey];
+            [userInfo setValue:self.response forKey:AFNetworkingOperationFailingURLResponseErrorKey];
+
+            if (![self hasAcceptableStatusCode]) {
+                NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 200;
+                [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected status code in (%@), got %d", @"AFNetworking", nil), AFStringFromIndexSet([[self class] acceptableStatusCodes]), statusCode] forKey:NSLocalizedDescriptionKey];
+                self.HTTPError = [[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
+            } else if (![self hasAcceptableContentType]) {
+                // Don't invalidate content type if there is no content
+                if ([self.responseData length] > 0) {
+                    [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected content type %@, got %@", @"AFNetworking", nil), [[self class] acceptableContentTypes], [self.response MIMEType]] forKey:NSLocalizedDescriptionKey];
+                    self.HTTPError = [[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
+                }
+            }
+        }
+    }
+
+    if (self.HTTPError) {
+        return self.HTTPError;
+    } else {
+        return [super error];
+    }
+}
+
+- (NSStringEncoding)responseStringEncoding {
+    // When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP. Data in character sets other than "ISO-8859-1" or its subsets MUST be labeled with an appropriate charset value.
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.4.1
+    if (self.response && !self.response.textEncodingName && self.responseData && [self.response respondsToSelector:@selector(allHeaderFields)]) {
+        NSString *type = nil;
+        AFGetMediaTypeAndSubtypeWithString([[self.response allHeaderFields] valueForKey:@"Content-Type"], &type, nil);
+
+        if ([type isEqualToString:@"text"]) {
+            return NSISOLatin1StringEncoding;
+        }
+    }
+
+    return [super responseStringEncoding];
+}
+
+- (void)pause {
+    unsigned long long offset = 0;
+    if ([self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey]) {
+        offset = [[self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey] unsignedLongLongValue];
+    } else {
+        offset = [[self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey] length];
+    }
+
+    NSMutableURLRequest *mutableURLRequest = [self.request mutableCopy];
+    if ([self.response respondsToSelector:@selector(allHeaderFields)] && [[self.response allHeaderFields] valueForKey:@"ETag"]) {
+        [mutableURLRequest setValue:[[self.response allHeaderFields] valueForKey:@"ETag"] forHTTPHeaderField:@"If-Range"];
+    }
+    [mutableURLRequest setValue:[NSString stringWithFormat:@"bytes=%llu-", offset] forHTTPHeaderField:@"Range"];
+    self.request = mutableURLRequest;
+
+    [super pause];
+}
+
+- (BOOL)hasAcceptableStatusCode {
+	if (!self.response) {
+		return NO;
+	}
+
+    NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 200;
+    return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:statusCode];
+}
+
+- (BOOL)hasAcceptableContentType {
+    if (!self.response) {
+		return NO;
+	}
+
+    // Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body. If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream".
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html
+    NSString *contentType = [self.response MIMEType];
+    if (!contentType) {
+        contentType = @"application/octet-stream";
+    }
+
+    return ![[self class] acceptableContentTypes] || [[[self class] acceptableContentTypes] containsObject:contentType];
+}
+
+- (void)setSuccessCallbackQueue:(dispatch_queue_t)successCallbackQueue {
+    if (successCallbackQueue != _successCallbackQueue) {
+        if (_successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_release(_successCallbackQueue);
+#endif
+            _successCallbackQueue = NULL;
+        }
+
+        if (successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_retain(successCallbackQueue);
+#endif
+            _successCallbackQueue = successCallbackQueue;
+        }
+    }
+}
+
+- (void)setFailureCallbackQueue:(dispatch_queue_t)failureCallbackQueue {
+    if (failureCallbackQueue != _failureCallbackQueue) {
+        if (_failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_release(_failureCallbackQueue);
+#endif
+            _failureCallbackQueue = NULL;
+        }
+
+        if (failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_retain(failureCallbackQueue);
+#endif
+            _failureCallbackQueue = failureCallbackQueue;
+        }
+    }
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(ZincHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(ZincHTTPRequestOperation *operation, NSError *error))failure
+{
+    // completionBlock is manually nilled out in AFURLConnectionOperation to break the retain cycle.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+    self.completionBlock = ^{
+        if (self.error) {
+            if (failure) {
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
+                });
+            }
+        } else {
+            if (success) {
+                dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    success(self, self.responseData);
+                });
+            }
+        }
+    };
+#pragma clang diagnostic pop
+}
+
+#pragma mark - AFHTTPRequestOperation
+
++ (NSIndexSet *)acceptableStatusCodes {
+    return [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
+}
+
++ (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes {
+    NSMutableIndexSet *mutableStatusCodes = [[NSMutableIndexSet alloc] initWithIndexSet:[self acceptableStatusCodes]];
+    [mutableStatusCodes addIndexes:statusCodes];
+    AFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableStatusCodes), ^(__unused id _self) {
+        return mutableStatusCodes;
+    });
+}
+
++ (NSSet *)acceptableContentTypes {
+    return nil;
+}
+
++ (void)addAcceptableContentTypes:(NSSet *)contentTypes {
+    NSMutableSet *mutableContentTypes = [[NSMutableSet alloc] initWithSet:[self acceptableContentTypes] copyItems:YES];
+    [mutableContentTypes unionSet:contentTypes];
+    AFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableContentTypes), ^(__unused id _self) {
+        return mutableContentTypes;
+    });
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    if ([[self class] isEqual:[ZincHTTPRequestOperation class]]) {
+        return YES;
+    }
+
+    return [[self acceptableContentTypes] intersectsSet:AFContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"])];
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/Zinc/ZincHTTPRequestOperation.m
+++ b/Zinc/ZincHTTPRequestOperation.m
@@ -1,4 +1,4 @@
-// AFHTTPRequestOperation.m
+// ZincHTTPRequestOperation.m
 //
 // Copyright (c) 2011 Gowalla (http://gowalla.com/)
 //
@@ -25,15 +25,15 @@
 
 // Workaround for change in imp_implementationWithBlock() with Xcode 4.5
 #if defined(__IPHONE_6_0) || defined(__MAC_10_8)
-#define AF_CAST_TO_BLOCK id
+#define ZINC_CAST_TO_BLOCK id
 #else
-#define AF_CAST_TO_BLOCK __bridge void *
+#define ZINC_CAST_TO_BLOCK __bridge void *
 #endif
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-selector-match"
 
-NSSet * AFContentTypesFromHTTPHeader(NSString *string) {
+NSSet * ZincContentTypesFromHTTPHeader(NSString *string) {
     if (!string) {
         return nil;
     }
@@ -57,7 +57,7 @@ NSSet * AFContentTypesFromHTTPHeader(NSString *string) {
     return [NSSet setWithSet:mutableContentTypes];
 }
 
-static void AFGetMediaTypeAndSubtypeWithString(NSString *string, NSString **type, NSString **subtype) {
+static void GetMediaTypeAndSubtypeWithString(NSString *string, NSString **type, NSString **subtype) {
     if (!string) {
         return;
     }
@@ -69,7 +69,7 @@ static void AFGetMediaTypeAndSubtypeWithString(NSString *string, NSString **type
     [scanner scanUpToString:@";" intoString:subtype];
 }
 
-static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
+static NSString * StringFromIndexSet(NSIndexSet *indexSet) {
     NSMutableString *string = [NSMutableString string];
 
     NSRange range = NSMakeRange([indexSet firstIndex], 1);
@@ -99,9 +99,9 @@ static NSString * AFStringFromIndexSet(NSIndexSet *indexSet) {
     return string;
 }
 
-static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL selector, id block) {
+static void SwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL selector, id block) {
     Method originalMethod = class_getClassMethod(klass, selector);
-    IMP implementation = imp_implementationWithBlock((AF_CAST_TO_BLOCK)block);
+    IMP implementation = imp_implementationWithBlock((ZINC_CAST_TO_BLOCK)block);
     class_replaceMethod(objc_getMetaClass([NSStringFromClass(klass) UTF8String]), selector, implementation, method_getTypeEncoding(originalMethod));
 }
 
@@ -142,18 +142,18 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
             NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
             [userInfo setValue:self.responseString forKey:NSLocalizedRecoverySuggestionErrorKey];
             [userInfo setValue:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
-            [userInfo setValue:self.request forKey:AFNetworkingOperationFailingURLRequestErrorKey];
-            [userInfo setValue:self.response forKey:AFNetworkingOperationFailingURLResponseErrorKey];
+            [userInfo setValue:self.request forKey:ZincNetworkingOperationFailingURLRequestErrorKey];
+            [userInfo setValue:self.response forKey:ZincNetworkingOperationFailingURLResponseErrorKey];
 
             if (![self hasAcceptableStatusCode]) {
                 NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 200;
-                [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected status code in (%@), got %d", @"AFNetworking", nil), AFStringFromIndexSet([[self class] acceptableStatusCodes]), statusCode] forKey:NSLocalizedDescriptionKey];
-                self.HTTPError = [[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
+                [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected status code in (%@), got %d", @"ZincNetworking", nil), StringFromIndexSet([[self class] acceptableStatusCodes]), statusCode] forKey:NSLocalizedDescriptionKey];
+                self.HTTPError = [[NSError alloc] initWithDomain:ZincNetworkingErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
             } else if (![self hasAcceptableContentType]) {
                 // Don't invalidate content type if there is no content
                 if ([self.responseData length] > 0) {
-                    [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected content type %@, got %@", @"AFNetworking", nil), [[self class] acceptableContentTypes], [self.response MIMEType]] forKey:NSLocalizedDescriptionKey];
-                    self.HTTPError = [[NSError alloc] initWithDomain:AFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
+                    [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected content type %@, got %@", @"ZincNetworking", nil), [[self class] acceptableContentTypes], [self.response MIMEType]] forKey:NSLocalizedDescriptionKey];
+                    self.HTTPError = [[NSError alloc] initWithDomain:ZincNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
                 }
             }
         }
@@ -171,7 +171,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
     // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.4.1
     if (self.response && !self.response.textEncodingName && self.responseData && [self.response respondsToSelector:@selector(allHeaderFields)]) {
         NSString *type = nil;
-        AFGetMediaTypeAndSubtypeWithString([[self.response allHeaderFields] valueForKey:@"Content-Type"], &type, nil);
+        GetMediaTypeAndSubtypeWithString([[self.response allHeaderFields] valueForKey:@"Content-Type"], &type, nil);
 
         if ([type isEqualToString:@"text"]) {
             return NSISOLatin1StringEncoding;
@@ -262,7 +262,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 - (void)setCompletionBlockWithSuccess:(void (^)(ZincHTTPRequestOperation *operation, id responseObject))success
                               failure:(void (^)(ZincHTTPRequestOperation *operation, NSError *error))failure
 {
-    // completionBlock is manually nilled out in AFURLConnectionOperation to break the retain cycle.
+    // completionBlock is manually nilled out in ZincURLConnectionOperation to break the retain cycle.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 #pragma clang diagnostic ignored "-Wgnu"
@@ -284,7 +284,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 #pragma clang diagnostic pop
 }
 
-#pragma mark - AFHTTPRequestOperation
+#pragma mark - ZincHTTPRequestOperation
 
 + (NSIndexSet *)acceptableStatusCodes {
     return [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
@@ -293,7 +293,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 + (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes {
     NSMutableIndexSet *mutableStatusCodes = [[NSMutableIndexSet alloc] initWithIndexSet:[self acceptableStatusCodes]];
     [mutableStatusCodes addIndexes:statusCodes];
-    AFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableStatusCodes), ^(__unused id _self) {
+    SwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableStatusCodes), ^(__unused id _self) {
         return mutableStatusCodes;
     });
 }
@@ -305,7 +305,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
 + (void)addAcceptableContentTypes:(NSSet *)contentTypes {
     NSMutableSet *mutableContentTypes = [[NSMutableSet alloc] initWithSet:[self acceptableContentTypes] copyItems:YES];
     [mutableContentTypes unionSet:contentTypes];
-    AFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableContentTypes), ^(__unused id _self) {
+    SwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableContentTypes), ^(__unused id _self) {
         return mutableContentTypes;
     });
 }
@@ -315,7 +315,7 @@ static void AFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL 
         return YES;
     }
 
-    return [[self acceptableContentTypes] intersectsSet:AFContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"])];
+    return [[self acceptableContentTypes] intersectsSet:ZincContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"])];
 }
 
 @end

--- a/Zinc/ZincRepo.h
+++ b/Zinc/ZincRepo.h
@@ -75,7 +75,7 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 #pragma mark -
 #pragma mark Configuration
 
-+ (void)setDefaultThreadPriority:(double)defaultThreadPriority;
++ (void) setDefaultThreadPriority:(double)defaultThreadPriority;
 
 
 
@@ -100,7 +100,7 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 /**
  @discussion Perform cleanup tasks. Runs automatically at repo initialization, but can be queued manually as well.
  */
-- (void)cleanWithCompletion:(dispatch_block_t)completion;
+- (void) cleanWithCompletion:(dispatch_block_t)completion;
 
 
 #pragma mark -

--- a/Zinc/ZincRepo.m
+++ b/Zinc/ZincRepo.m
@@ -325,7 +325,6 @@ NSString* const ZincRepoTaskNotificationTaskKey = @"task";
         
         for (NSURL* bundleRes in available) {
             if (![active containsObject:bundleRes]) {
-                //ZINC_DEBUG_LOG(@"deleting: %@", bundleRes);
                 [self deleteBundleWithID:[bundleRes zincBundleID] version:[bundleRes zincBundleVersion]];
             }
         }
@@ -372,7 +371,6 @@ NSString* const ZincRepoTaskNotificationTaskKey = @"task";
     // set to nil to unsubscribe from notitifcations
     self.reachability = nil;
     self.downloadPolicy = nil;
-    
 }
 
 #pragma mark Notifications
@@ -1108,32 +1106,30 @@ NSString* const ZincRepoTaskNotificationTaskKey = @"task";
     if (extInfo != nil) {
         return extInfo.bundleRootPath;
     }
-    
+
     NSString* bundleDirName = [NSString stringWithFormat:@"%@-%d", bundleID, version];
     NSString* bundlePath = [[self bundlesPath] stringByAppendingPathComponent:bundleDirName];
     return bundlePath;
 }
 
 
-     - (ZincBundle*) bundleWithID:(NSString*)bundleID
-    {
-        if (!self.isInitialized) {
-            @throw [NSException
-                    exceptionWithName:NSInternalInconsistencyException
-                    reason:[NSString stringWithFormat:@"repo not initialized"]
-                    userInfo:nil];
-        }
-
-        NSString* distro = [self.index trackedDistributionForBundleID:bundleID];
-        ZincVersion version = [self versionForBundleID:bundleID distribution:distro];
-        if (version == ZincVersionInvalid) {
-            return nil;
-        }
-
-        return [self.bundleManager bundleWithID:bundleID version:version];
+- (ZincBundle*) bundleWithID:(NSString*)bundleID
+{
+    if (!self.isInitialized) {
+        @throw [NSException
+                exceptionWithName:NSInternalInconsistencyException
+                reason:[NSString stringWithFormat:@"repo not initialized"]
+                userInfo:nil];
     }
 
+    NSString* distro = [self.index trackedDistributionForBundleID:bundleID];
+    ZincVersion version = [self versionForBundleID:bundleID distribution:distro];
+    if (version == ZincVersionInvalid) {
+        return nil;
+    }
 
+    return [self.bundleManager bundleWithID:bundleID version:version];
+}
 
 - (ZincBundleState) stateForBundleWithID:(NSString*)bundleID
 {

--- a/Zinc/ZincRepoTaskManager.m
+++ b/Zinc/ZincRepoTaskManager.m
@@ -15,6 +15,7 @@
 #import "ZincDownloadPolicy.h"
 #import "ZincOperationQueueGroup.h"
 #import "ZincTasks.h"
+#import "ZincHTTPRequestOperation.h"
 
 static NSString* kvo_taskIsFinished = @"kvo_taskIsFinished";
 
@@ -78,7 +79,7 @@ static NSString* kvo_taskIsFinished = @"kvo_taskIsFinished";
 
 - (void) addOperation:(NSOperation*)operation
 {
-    if ([operation isKindOfClass:[AFURLConnectionOperation class]]) {
+    if ([operation isKindOfClass:[ZincHTTPRequestOperation class]]) {
         [self.networkQueue addOperation:operation];
     } else if ([operation isKindOfClass:[ZincInitializationTask class]] ||
                [operation isKindOfClass:[ZincRepoIndexUpdateTask class]] ||

--- a/Zinc/ZincSourceUpdateTask.m
+++ b/Zinc/ZincSourceUpdateTask.m
@@ -47,7 +47,7 @@
     NSError* error = nil;
     
     NSURLRequest* request = [self.sourceURL urlRequestForCatalogIndex];
-    AFHTTPRequestOperation* requestOp = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    ZincHTTPRequestOperation* requestOp = [[ZincHTTPRequestOperation alloc] initWithRequest:request];
     [self queueChildOperation:requestOp];
     
     [requestOp waitUntilFinished];

--- a/Zinc/ZincURLConnectionOperation.h
+++ b/Zinc/ZincURLConnectionOperation.h
@@ -1,4 +1,4 @@
-// AFURLConnectionOperation.h
+// ZincURLConnectionOperation.h
 //
 // Copyright (c) 2011 Gowalla (http://gowalla.com/)
 //
@@ -25,17 +25,17 @@
 #import <Availability.h>
 
 /**
- `AFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
+ `ZincURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
 
  ## Subclassing Notes
 
  This is the base class of all network request operations. You may wish to create your own subclass in order to implement additional `NSURLConnection` delegate methods (see "`NSURLConnection` Delegate Methods" below), or to provide additional properties and/or class constructors.
 
- If you are creating a subclass that communicates over the HTTP or HTTPS protocols, you may want to consider subclassing `AFHTTPRequestOperation` instead, as it supports specifying acceptable content types or status codes.
+ If you are creating a subclass that communicates over the HTTP or HTTPS protocols, you may want to consider subclassing `ZincHTTPRequestOperation` instead, as it supports specifying acceptable content types or status codes.
 
  ## NSURLConnection Delegate Methods
 
- `AFURLConnectionOperation` implements the following `NSURLConnection` delegate methods:
+ `ZincURLConnectionOperation` implements the following `NSURLConnection` delegate methods:
 
  - `connection:didReceiveResponse:`
  - `connection:didReceiveData:`
@@ -46,7 +46,7 @@
  - `connectionShouldUseCredentialStorage:`
  - `connection:needNewBodyStream:`
  
- When _AFNETWORKING_PIN_SSL_CERTIFICATES_ is defined, the following authentication delegate method is implemented:
+ When _ZINCNETWORKING_PIN_SSL_CERTIFICATES_ is defined, the following authentication delegate method is implemented:
  
  - `connection:willSendRequestForAuthenticationChallenge:`
  
@@ -59,13 +59,13 @@
 
  ## Class Constructors
 
- Class constructors, or methods that return an unowned instance, are the preferred way for subclasses to encapsulate any particular logic for handling the setup or parsing of response data. For instance, `AFJSONRequestOperation` provides `JSONRequestOperationWithRequest:success:failure:`, which takes block arguments, whose parameter on for a successful request is the JSON object initialized from the `response data`.
+ Class constructors, or methods that return an unowned instance, are the preferred way for subclasses to encapsulate any particular logic for handling the setup or parsing of response data.
 
  ## Callbacks and Completion Blocks
 
- The built-in `completionBlock` provided by `NSOperation` allows for custom behavior to be executed after the request finishes. It is a common pattern for class constructors in subclasses to take callback block parameters, and execute them conditionally in the body of its `completionBlock`. Make sure to handle cancelled operations appropriately when setting a `completionBlock` (i.e. returning early before parsing response data). See the implementation of any of the `AFHTTPRequestOperation` subclasses for an example of this.
+ The built-in `completionBlock` provided by `NSOperation` allows for custom behavior to be executed after the request finishes. It is a common pattern for class constructors in subclasses to take callback block parameters, and execute them conditionally in the body of its `completionBlock`. Make sure to handle cancelled operations appropriately when setting a `completionBlock` (i.e. returning early before parsing response data). See the implementation of any of the `ZincHTTPRequestOperation` subclasses for an example of this.
 
- Subclasses are strongly discouraged from overriding `setCompletionBlock:`, as `AFURLConnectionOperation`'s implementation includes a workaround to mitigate retain cycles, and what Apple rather ominously refers to as ["The Deallocation Problem"](http://developer.apple.com/library/ios/#technotes/tn2109/).
+ Subclasses are strongly discouraged from overriding `setCompletionBlock:`, as `ZincURLConnectionOperation`'s implementation includes a workaround to mitigate retain cycles, and what Apple rather ominously refers to as ["The Deallocation Problem"](http://developer.apple.com/library/ios/#technotes/tn2109/).
  
  ## SSL Pinning
  
@@ -73,11 +73,11 @@
  
  SSL with certificate pinning is strongly recommended for any application that transmits sensitive information to an external webservice.
 
- When `_AFNETWORKING_PIN_SSL_CERTIFICATES_` is defined and the Security framework is linked, connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
+ When `_ZINCNETWORKING_PIN_SSL_CERTIFICATES_` is defined and the Security framework is linked, connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
 
  ## NSCoding & NSCopying Conformance
 
- `AFURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
+ `ZincURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
 
  ### NSCoding Caveats
 
@@ -91,12 +91,12 @@
  - Operation copies do not include `completionBlock`. `completionBlock` often strongly captures a reference to `self`, which would otherwise have the unintuitive side-effect of pointing to the _original_ operation when copied.
  */
 
-#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+#ifdef _ZINCNETWORKING_PIN_SSL_CERTIFICATES_
 typedef enum {
-    AFSSLPinningModeNone,
-    AFSSLPinningModePublicKey,
-    AFSSLPinningModeCertificate,
-} AFURLConnectionOperationSSLPinningMode;
+    ZincSSLPinningModeNone,
+    ZincSSLPinningModePublicKey,
+    ZincSSLPinningModeCertificate,
+} ZincURLConnectionOperationSSLPinningMode;
 #endif
 
 @interface ZincURLConnectionOperation : NSOperation <NSURLConnectionDelegate,
@@ -137,7 +137,7 @@ NSCoding, NSCopying>
 /**
  Whether the connection should accept an invalid SSL certificate.
  
- If `_AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_` is set, this property defaults to `YES` for backwards compatibility. Otherwise, this property defaults to `NO`.
+ If `_ZINCNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_` is set, this property defaults to `YES` for backwards compatibility. Otherwise, this property defaults to `NO`.
  */
 @property (nonatomic, assign) BOOL allowsInvalidSSLCertificate;
 
@@ -181,12 +181,12 @@ NSCoding, NSCopying>
 @property (nonatomic, strong) NSURLCredential *credential;
 
 /**
- The pinning mode which will be used for SSL connections. `AFSSLPinningModePublicKey` by default.
+ The pinning mode which will be used for SSL connections. `ZincSSLPinningModePublicKey` by default.
  
- To enable SSL Pinning, `#define _AFNETWORKING_PIN_SSL_CERTIFICATES_` in `Prefix.pch`. Also, make sure that the Security framework is linked with the binary. See the "SSL Pinning" section in the `AFURLConnectionOperation`" header for more information.
+ To enable SSL Pinning, `#define _ZINCNETWORKING_PIN_SSL_CERTIFICATES_` in `Prefix.pch`. Also, make sure that the Security framework is linked with the binary. See the "SSL Pinning" section in the `ZincURLConnectionOperation`" header for more information.
  */
-#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
-@property (nonatomic, assign) AFURLConnectionOperationSSLPinningMode SSLPinningMode;
+#ifdef _ZINCNETWORKING_PIN_SSL_CERTIFICATES_
+@property (nonatomic, assign) ZincURLConnectionOperationSSLPinningMode SSLPinningMode;
 #endif
 
 ///------------------------
@@ -217,7 +217,7 @@ NSCoding, NSCopying>
 @property (nonatomic, strong) NSDictionary *userInfo;
 
 ///------------------------------------------------------
-/// @name Initializing an AFURLConnectionOperation Object
+/// @name Initializing an ZincURLConnectionOperation Object
 ///------------------------------------------------------
 
 /**
@@ -250,7 +250,7 @@ NSCoding, NSCopying>
 /**
  Resumes the execution of the paused request operation.
 
- Pause/Resume behavior varies depending on the underlying implementation for the operation class. In its base implementation, resuming a paused requests restarts the original request. However, since HTTP defines a specification for how to request a specific content range, `AFHTTPRequestOperation` will resume downloading the request from where it left off, instead of restarting the original request.
+ Pause/Resume behavior varies depending on the underlying implementation for the operation class. In its base implementation, resuming a paused requests restarts the original request. However, since HTTP defines a specification for how to request a specific content range, `ZincHTTPRequestOperation` will resume downloading the request from where it left off, instead of restarting the original request.
  */
 - (void)resume;
 
@@ -289,7 +289,7 @@ NSCoding, NSCopying>
 /// @name Setting NSURLConnection Delegate Callbacks
 ///-------------------------------------------------
 
-#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+#ifdef _ZINCNETWORKING_PIN_SSL_CERTIFICATES_
 /**
  Sets a block to be executed when the connection will authenticate a challenge in order to download its request, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequestForAuthenticationChallenge:`.
  
@@ -345,52 +345,52 @@ NSCoding, NSCopying>
 /**
  ## SSL Pinning Options
 
- The following constants are provided by `AFURLConnectionOperation` as possible SSL Pinning options.
+ The following constants are provided by `ZincURLConnectionOperation` as possible SSL Pinning options.
 
  enum {
- AFSSLPinningModeNone,
- AFSSLPinningModePublicKey,
- AFSSLPinningModeCertificate,
+ ZincSSLPinningModeNone,
+ ZincSSLPinningModePublicKey,
+ ZincSSLPinningModeCertificate,
  }
  
- `AFSSLPinningModeNone`
+ `ZincSSLPinningModeNone`
  Do not pin SSL connections
 
- `AFSSLPinningModePublicKey`
+ `ZincSSLPinningModePublicKey`
  Pin SSL connections to certificate public key (SPKI).
 
- `AFSSLPinningModeCertificate`
+ `ZincSSLPinningModeCertificate`
  Pin SSL connections to exact certificate. This may cause problems when your certificate expires and needs re-issuance.
 
  ## User info dictionary keys
 
  These keys may exist in the user info dictionary, in addition to those defined for NSError.
 
- - `NSString * const AFNetworkingOperationFailingURLRequestErrorKey`
- - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
+ - `NSString * const ZincNetworkingOperationFailingURLRequestErrorKey`
+ - `NSString * const ZincNetworkingOperationFailingURLResponseErrorKey`
 
  ### Constants
 
- `AFNetworkingOperationFailingURLRequestErrorKey`
- The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+ `ZincNetworkingOperationFailingURLRequestErrorKey`
+ The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `ZincNetworkingErrorDomain`.
 
- `AFNetworkingOperationFailingURLResponseErrorKey`
- The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+ `ZincNetworkingOperationFailingURLResponseErrorKey`
+ The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `ZincNetworkingErrorDomain`.
 
  ## Error Domains
 
  The following error domain is predefined.
 
- - `NSString * const AFNetworkingErrorDomain`
+ - `NSString * const ZincNetworkingErrorDomain`
 
  ### Constants
 
- `AFNetworkingErrorDomain`
- AFNetworking errors. Error codes for `AFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ `ZincNetworkingErrorDomain`
+ ZincNetworking errors. Error codes for `ZincNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
  */
-extern NSString * const AFNetworkingErrorDomain;
-extern NSString * const AFNetworkingOperationFailingURLRequestErrorKey;
-extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
+extern NSString * const ZincNetworkingErrorDomain;
+extern NSString * const ZincNetworkingOperationFailingURLRequestErrorKey;
+extern NSString * const ZincNetworkingOperationFailingURLResponseErrorKey;
 
 ///--------------------
 /// @name Notifications
@@ -399,9 +399,9 @@ extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
 /**
  Posted when an operation begins executing.
  */
-extern NSString * const AFNetworkingOperationDidStartNotification;
+extern NSString * const ZincNetworkingOperationDidStartNotification;
 
 /**
  Posted when an operation finishes.
  */
-extern NSString * const AFNetworkingOperationDidFinishNotification;
+extern NSString * const ZincNetworkingOperationDidFinishNotification;

--- a/Zinc/ZincURLConnectionOperation.h
+++ b/Zinc/ZincURLConnectionOperation.h
@@ -1,0 +1,407 @@
+// AFURLConnectionOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#import <Availability.h>
+
+/**
+ `AFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
+
+ ## Subclassing Notes
+
+ This is the base class of all network request operations. You may wish to create your own subclass in order to implement additional `NSURLConnection` delegate methods (see "`NSURLConnection` Delegate Methods" below), or to provide additional properties and/or class constructors.
+
+ If you are creating a subclass that communicates over the HTTP or HTTPS protocols, you may want to consider subclassing `AFHTTPRequestOperation` instead, as it supports specifying acceptable content types or status codes.
+
+ ## NSURLConnection Delegate Methods
+
+ `AFURLConnectionOperation` implements the following `NSURLConnection` delegate methods:
+
+ - `connection:didReceiveResponse:`
+ - `connection:didReceiveData:`
+ - `connectionDidFinishLoading:`
+ - `connection:didFailWithError:`
+ - `connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:`
+ - `connection:willCacheResponse:`
+ - `connectionShouldUseCredentialStorage:`
+ - `connection:needNewBodyStream:`
+ 
+ When _AFNETWORKING_PIN_SSL_CERTIFICATES_ is defined, the following authentication delegate method is implemented:
+ 
+ - `connection:willSendRequestForAuthenticationChallenge:`
+ 
+ Otherwise, the following authentication delegate methods are implemented:
+ 
+ - `connection:canAuthenticateAgainstProtectionSpace:`
+ - `connection:didReceiveAuthenticationChallenge:`
+
+ If any of these methods are overridden in a subclass, they _must_ call the `super` implementation first.
+
+ ## Class Constructors
+
+ Class constructors, or methods that return an unowned instance, are the preferred way for subclasses to encapsulate any particular logic for handling the setup or parsing of response data. For instance, `AFJSONRequestOperation` provides `JSONRequestOperationWithRequest:success:failure:`, which takes block arguments, whose parameter on for a successful request is the JSON object initialized from the `response data`.
+
+ ## Callbacks and Completion Blocks
+
+ The built-in `completionBlock` provided by `NSOperation` allows for custom behavior to be executed after the request finishes. It is a common pattern for class constructors in subclasses to take callback block parameters, and execute them conditionally in the body of its `completionBlock`. Make sure to handle cancelled operations appropriately when setting a `completionBlock` (i.e. returning early before parsing response data). See the implementation of any of the `AFHTTPRequestOperation` subclasses for an example of this.
+
+ Subclasses are strongly discouraged from overriding `setCompletionBlock:`, as `AFURLConnectionOperation`'s implementation includes a workaround to mitigate retain cycles, and what Apple rather ominously refers to as ["The Deallocation Problem"](http://developer.apple.com/library/ios/#technotes/tn2109/).
+ 
+ ## SSL Pinning
+ 
+ Relying on the CA trust model to validate SSL certificates exposes your app to security vulnerabilities, such as man-in-the-middle attacks. For applications that connect to known servers, SSL certificate pinning provides an increased level of security, by checking server certificate validity against those specified in the app bundle.
+ 
+ SSL with certificate pinning is strongly recommended for any application that transmits sensitive information to an external webservice.
+
+ When `_AFNETWORKING_PIN_SSL_CERTIFICATES_` is defined and the Security framework is linked, connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
+
+ ## NSCoding & NSCopying Conformance
+
+ `AFURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
+
+ ### NSCoding Caveats
+
+ - Encoded operations do not include any block or stream properties. Be sure to set `completionBlock`, `outputStream`, and any callback blocks as necessary when using `-initWithCoder:` or `NSKeyedUnarchiver`.
+ - Operations are paused on `encodeWithCoder:`. If the operation was encoded while paused or still executing, its archived state will return `YES` for `isReady`. Otherwise, the state of an operation when encoding will remain unchanged.
+
+ ### NSCopying Caveats
+
+ - `-copy` and `-copyWithZone:` return a new operation with the `NSURLRequest` of the original. So rather than an exact copy of the operation at that particular instant, the copying mechanism returns a completely new instance, which can be useful for retrying operations.
+ - A copy of an operation will not include the `outputStream` of the original.
+ - Operation copies do not include `completionBlock`. `completionBlock` often strongly captures a reference to `self`, which would otherwise have the unintuitive side-effect of pointing to the _original_ operation when copied.
+ */
+
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+typedef enum {
+    AFSSLPinningModeNone,
+    AFSSLPinningModePublicKey,
+    AFSSLPinningModeCertificate,
+} AFURLConnectionOperationSSLPinningMode;
+#endif
+
+@interface ZincURLConnectionOperation : NSOperation <NSURLConnectionDelegate,
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000) || \
+    (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
+NSURLConnectionDataDelegate, 
+#endif
+NSCoding, NSCopying>
+
+///-------------------------------
+/// @name Accessing Run Loop Modes
+///-------------------------------
+
+/**
+ The run loop modes in which the operation will run on the network thread. By default, this is a single-member set containing `NSRunLoopCommonModes`.
+ */
+@property (nonatomic, strong) NSSet *runLoopModes;
+
+///-----------------------------------------
+/// @name Getting URL Connection Information
+///-----------------------------------------
+
+/**
+ The request used by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSURLRequest *request;
+
+/**
+ The last response received by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSURLResponse *response;
+
+/**
+ The error, if any, that occurred in the lifecycle of the request.
+ */
+@property (readonly, nonatomic, strong) NSError *error;
+
+/**
+ Whether the connection should accept an invalid SSL certificate.
+ 
+ If `_AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_` is set, this property defaults to `YES` for backwards compatibility. Otherwise, this property defaults to `NO`.
+ */
+@property (nonatomic, assign) BOOL allowsInvalidSSLCertificate;
+
+///----------------------------
+/// @name Getting Response Data
+///----------------------------
+
+/**
+ The data received during the request.
+ */
+@property (readonly, nonatomic, strong) NSData *responseData;
+
+/**
+ The string representation of the response data.
+ */
+@property (readonly, nonatomic, copy) NSString *responseString;
+
+/**
+ The string encoding of the response.
+
+ If the response does not specify a valid string encoding, `responseStringEncoding` will return `NSUTF8StringEncoding`.
+ */
+@property (readonly, nonatomic, assign) NSStringEncoding responseStringEncoding;
+
+///-------------------------------
+/// @name Managing URL Credentials
+///-------------------------------
+
+/**
+ Whether the URL connection should consult the credential storage for authenticating the connection. `YES` by default.
+
+ This is the value that is returned in the `NSURLConnectionDelegate` method `-connectionShouldUseCredentialStorage:`.
+ */
+@property (nonatomic, assign) BOOL shouldUseCredentialStorage;
+
+/**
+ The credential used for authentication challenges in `-connection:didReceiveAuthenticationChallenge:`.
+
+ This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
+ */
+@property (nonatomic, strong) NSURLCredential *credential;
+
+/**
+ The pinning mode which will be used for SSL connections. `AFSSLPinningModePublicKey` by default.
+ 
+ To enable SSL Pinning, `#define _AFNETWORKING_PIN_SSL_CERTIFICATES_` in `Prefix.pch`. Also, make sure that the Security framework is linked with the binary. See the "SSL Pinning" section in the `AFURLConnectionOperation`" header for more information.
+ */
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+@property (nonatomic, assign) AFURLConnectionOperationSSLPinningMode SSLPinningMode;
+#endif
+
+///------------------------
+/// @name Accessing Streams
+///------------------------
+
+/**
+ The input stream used to read data to be sent during the request.
+
+ This property acts as a proxy to the `HTTPBodyStream` property of `request`.
+ */
+@property (nonatomic, strong) NSInputStream *inputStream;
+
+/**
+ The output stream that is used to write data received until the request is finished.
+
+ By default, data is accumulated into a buffer that is stored into `responseData` upon completion of the request. When `outputStream` is set, the data will not be accumulated into an internal buffer, and as a result, the `responseData` property of the completed request will be `nil`. The output stream will be scheduled in the network thread runloop upon being set.
+ */
+@property (nonatomic, strong) NSOutputStream *outputStream;
+
+///---------------------------------------------
+/// @name Managing Request Operation Information
+///---------------------------------------------
+
+/**
+ The user info dictionary for the receiver.
+ */
+@property (nonatomic, strong) NSDictionary *userInfo;
+
+///------------------------------------------------------
+/// @name Initializing an AFURLConnectionOperation Object
+///------------------------------------------------------
+
+/**
+ Initializes and returns a newly allocated operation object with a url connection configured with the specified url request.
+ 
+ This is the designated initializer.
+ 
+ @param urlRequest The request object to be used by the operation connection.
+ */
+- (id)initWithRequest:(NSURLRequest *)urlRequest;
+
+///----------------------------------
+/// @name Pausing / Resuming Requests
+///----------------------------------
+
+/**
+ Pauses the execution of the request operation.
+
+ A paused operation returns `NO` for `-isReady`, `-isExecuting`, and `-isFinished`. As such, it will remain in an `NSOperationQueue` until it is either cancelled or resumed. Pausing a finished, cancelled, or paused operation has no effect.
+ */
+- (void)pause;
+
+/**
+ Whether the request operation is currently paused.
+
+ @return `YES` if the operation is currently paused, otherwise `NO`.
+ */
+- (BOOL)isPaused;
+
+/**
+ Resumes the execution of the paused request operation.
+
+ Pause/Resume behavior varies depending on the underlying implementation for the operation class. In its base implementation, resuming a paused requests restarts the original request. However, since HTTP defines a specification for how to request a specific content range, `AFHTTPRequestOperation` will resume downloading the request from where it left off, instead of restarting the original request.
+ */
+- (void)resume;
+
+///----------------------------------------------
+/// @name Configuring Backgrounding Task Behavior
+///----------------------------------------------
+
+/**
+ Specifies that the operation should continue execution after the app has entered the background, and the expiration handler for that background task.
+
+ @param handler A handler to be called shortly before the application’s remaining background time reaches 0. The handler is wrapped in a block that cancels the operation, and cleans up and marks the end of execution, unlike the `handler` parameter in `UIApplication -beginBackgroundTaskWithExpirationHandler:`, which expects this to be done in the handler itself. The handler is called synchronously on the main thread, thus blocking the application’s suspension momentarily while the application is notified.
+ */
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler;
+#endif
+
+///---------------------------------
+/// @name Setting Progress Callbacks
+///---------------------------------
+
+/**
+ Sets a callback to be called when an undetermined number of bytes have been uploaded to the server.
+
+ @param block A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
+ */
+- (void)setUploadProgressBlock:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))block;
+
+/**
+ Sets a callback to be called when an undetermined number of bytes have been downloaded from the server.
+
+ @param block A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
+ */
+- (void)setDownloadProgressBlock:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block;
+
+///-------------------------------------------------
+/// @name Setting NSURLConnection Delegate Callbacks
+///-------------------------------------------------
+
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+/**
+ Sets a block to be executed when the connection will authenticate a challenge in order to download its request, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequestForAuthenticationChallenge:`.
+ 
+ @param block A block object to be executed when the connection will authenticate a challenge in order to download its request. The block has no return type and takes two arguments: the URL connection object, and the challenge that must be authenticated. This block must invoke one of the challenge-responder methods (NSURLAuthenticationChallengeSender protocol).
+ 
+ If `allowsInvalidSSLCertificate` is set to YES, `connection:willSendRequestForAuthenticationChallenge:` will attempt to have the challenge sender use credentials with invalid SSL certificates.
+ */
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block;
+
+#else
+
+/**
+ Sets a block to be executed to determine whether the connection should be able to respond to a protection space's form of authentication, as handled by the `NSURLConnectionDelegate` method `connection:canAuthenticateAgainstProtectionSpace:`.
+ 
+ If `allowsInvalidSSLCertificate` is set to YES, `connection:canAuthenticateAgainstProtectionSpace:` will accept invalid SSL certificates, returning `YES` if the protection space authentication method is `NSURLAuthenticationMethodServerTrust`.
+
+ @param block A block object to be executed to determine whether the connection should be able to respond to a protection space's form of authentication. The block has a `BOOL` return type and takes two arguments: the URL connection object, and the protection space to authenticate against.  
+ */
+- (void)setAuthenticationAgainstProtectionSpaceBlock:(BOOL (^)(NSURLConnection *connection, NSURLProtectionSpace *protectionSpace))block;
+
+/**
+ Sets a block to be executed when the connection must authenticate a challenge in order to download its request, as handled by the `NSURLConnectionDelegate` method `connection:didReceiveAuthenticationChallenge:`.
+
+ @param block A block object to be executed when the connection must authenticate a challenge in order to download its request. The block has no return type and takes two arguments: the URL connection object, and the challenge that must be authenticated.
+
+  If `allowsInvalidSSLCertificate` is set to YES, `connection:didReceiveAuthenticationChallenge:` will attempt to have the challenge sender use credentials with invalid SSL certificates.
+ */
+- (void)setAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block;
+
+#endif
+
+/**
+ Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequest:redirectResponse:`.
+
+ @param block A block object to be executed when the request URL was changed. The block returns an `NSURLRequest` object, the URL request to redirect, and takes three arguments: the URL connection object, the the proposed redirected request, and the URL response that caused the redirect.
+ */
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block;
+
+
+/**
+ Sets a block to be executed to modify the response a connection will cache, if any, as handled by the `NSURLConnectionDelegate` method `connection:willCacheResponse:`.
+
+ @param block A block object to be executed to determine what response a connection will cache, if any. The block returns an `NSCachedURLResponse` object, the cached response to store in memory or `nil` to prevent the response from being cached, and takes two arguments: the URL connection object, and the cached response provided for the request.
+ */
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block;
+
+@end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## SSL Pinning Options
+
+ The following constants are provided by `AFURLConnectionOperation` as possible SSL Pinning options.
+
+ enum {
+ AFSSLPinningModeNone,
+ AFSSLPinningModePublicKey,
+ AFSSLPinningModeCertificate,
+ }
+ 
+ `AFSSLPinningModeNone`
+ Do not pin SSL connections
+
+ `AFSSLPinningModePublicKey`
+ Pin SSL connections to certificate public key (SPKI).
+
+ `AFSSLPinningModeCertificate`
+ Pin SSL connections to exact certificate. This may cause problems when your certificate expires and needs re-issuance.
+
+ ## User info dictionary keys
+
+ These keys may exist in the user info dictionary, in addition to those defined for NSError.
+
+ - `NSString * const AFNetworkingOperationFailingURLRequestErrorKey`
+ - `NSString * const AFNetworkingOperationFailingURLResponseErrorKey`
+
+ ### Constants
+
+ `AFNetworkingOperationFailingURLRequestErrorKey`
+ The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+
+ `AFNetworkingOperationFailingURLResponseErrorKey`
+ The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `AFNetworkingErrorDomain`.
+
+ ## Error Domains
+
+ The following error domain is predefined.
+
+ - `NSString * const AFNetworkingErrorDomain`
+
+ ### Constants
+
+ `AFNetworkingErrorDomain`
+ AFNetworking errors. Error codes for `AFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ */
+extern NSString * const AFNetworkingErrorDomain;
+extern NSString * const AFNetworkingOperationFailingURLRequestErrorKey;
+extern NSString * const AFNetworkingOperationFailingURLResponseErrorKey;
+
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted when an operation begins executing.
+ */
+extern NSString * const AFNetworkingOperationDidStartNotification;
+
+/**
+ Posted when an operation finishes.
+ */
+extern NSString * const AFNetworkingOperationDidFinishNotification;

--- a/Zinc/ZincURLConnectionOperation.m
+++ b/Zinc/ZincURLConnectionOperation.m
@@ -1,0 +1,909 @@
+// AFURLConnectionOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ZincURLConnectionOperation.h"
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <UIKit/UIKit.h>
+#endif
+
+#if !__has_feature(objc_arc)
+#error AFNetworking must be built with ARC.
+// You can turn on ARC for only AFNetworking files by adding -fobjc-arc to the build phase for each of its files.
+#endif
+
+typedef enum {
+    AFOperationPausedState      = -1,
+    AFOperationReadyState       = 1,
+    AFOperationExecutingState   = 2,
+    AFOperationFinishedState    = 3,
+} _AFOperationState;
+
+typedef signed short AFOperationState;
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+typedef UIBackgroundTaskIdentifier AFBackgroundTaskIdentifier;
+#else
+typedef id AFBackgroundTaskIdentifier;
+#endif
+
+static NSString * const kAFNetworkingLockName = @"com.alamofire.networking.operation.lock";
+
+NSString * const AFNetworkingErrorDomain = @"AFNetworkingErrorDomain";
+NSString * const AFNetworkingOperationFailingURLRequestErrorKey = @"AFNetworkingOperationFailingURLRequestErrorKey";
+NSString * const AFNetworkingOperationFailingURLResponseErrorKey = @"AFNetworkingOperationFailingURLResponseErrorKey";
+
+NSString * const AFNetworkingOperationDidStartNotification = @"com.alamofire.networking.operation.start";
+NSString * const AFNetworkingOperationDidFinishNotification = @"com.alamofire.networking.operation.finish";
+
+typedef void (^AFURLConnectionOperationProgressBlock)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
+#ifndef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+typedef BOOL (^AFURLConnectionOperationAuthenticationAgainstProtectionSpaceBlock)(NSURLConnection *connection, NSURLProtectionSpace *protectionSpace);
+#endif
+typedef void (^AFURLConnectionOperationAuthenticationChallengeBlock)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge);
+typedef NSCachedURLResponse * (^AFURLConnectionOperationCacheResponseBlock)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse);
+typedef NSURLRequest * (^AFURLConnectionOperationRedirectResponseBlock)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse);
+
+static inline NSString * AFKeyPathFromOperationState(AFOperationState state) {
+    switch (state) {
+        case AFOperationReadyState:
+            return @"isReady";
+        case AFOperationExecutingState:
+            return @"isExecuting";
+        case AFOperationFinishedState:
+            return @"isFinished";
+        case AFOperationPausedState:
+            return @"isPaused";
+        default:
+            return @"state";
+    }
+}
+
+static inline BOOL AFStateTransitionIsValid(AFOperationState fromState, AFOperationState toState, BOOL isCancelled) {
+    switch (fromState) {
+        case AFOperationReadyState:
+            switch (toState) {
+                case AFOperationPausedState:
+                case AFOperationExecutingState:
+                    return YES;
+                case AFOperationFinishedState:
+                    return isCancelled;
+                default:
+                    return NO;
+            }
+        case AFOperationExecutingState:
+            switch (toState) {
+                case AFOperationPausedState:
+                case AFOperationFinishedState:
+                    return YES;
+                default:
+                    return NO;
+            }
+        case AFOperationFinishedState:
+            return NO;
+        case AFOperationPausedState:
+            return toState == AFOperationReadyState;
+        default:
+            return YES;
+    }
+}
+
+#if !defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+static NSData *AFSecKeyGetData(SecKeyRef key) {
+    CFDataRef data = NULL;
+    
+    OSStatus status = SecItemExport(key, kSecFormatUnknown, kSecItemPemArmour, NULL, &data);
+    NSCAssert(status == errSecSuccess, @"SecItemExport error: %ld", (long int)status);
+    NSCParameterAssert(data);
+    
+    return (__bridge_transfer NSData *)data;
+}
+#endif
+
+static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    return [(__bridge id)key1 isEqual:(__bridge id)key2];
+#else
+    return [AFSecKeyGetData(key1) isEqual:AFSecKeyGetData(key2)];
+#endif
+}
+
+@interface ZincURLConnectionOperation ()
+@property (readwrite, nonatomic, assign) AFOperationState state;
+@property (readwrite, nonatomic, assign, getter = isCancelled) BOOL cancelled;
+@property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
+@property (readwrite, nonatomic, strong) NSURLConnection *connection;
+@property (readwrite, nonatomic, strong) NSURLRequest *request;
+@property (readwrite, nonatomic, strong) NSURLResponse *response;
+@property (readwrite, nonatomic, strong) NSError *error;
+@property (readwrite, nonatomic, strong) NSData *responseData;
+@property (readwrite, nonatomic, copy) NSString *responseString;
+@property (readwrite, nonatomic, assign) NSStringEncoding responseStringEncoding;
+@property (readwrite, nonatomic, assign) long long totalBytesRead;
+@property (readwrite, nonatomic, assign) AFBackgroundTaskIdentifier backgroundTaskIdentifier;
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationProgressBlock uploadProgress;
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationProgressBlock downloadProgress;
+#ifndef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationAuthenticationAgainstProtectionSpaceBlock authenticationAgainstProtectionSpace;
+#endif
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationAuthenticationChallengeBlock authenticationChallenge;
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationCacheResponseBlock cacheResponse;
+@property (readwrite, nonatomic, copy) AFURLConnectionOperationRedirectResponseBlock redirectResponse;
+
+- (void)operationDidStart;
+- (void)finish;
+- (void)cancelConnection;
+@end
+
+@implementation ZincURLConnectionOperation
+@synthesize state = _state;
+@synthesize cancelled = _cancelled;
+@synthesize connection = _connection;
+@synthesize runLoopModes = _runLoopModes;
+@synthesize request = _request;
+@synthesize response = _response;
+@synthesize error = _error;
+@synthesize allowsInvalidSSLCertificate = _allowsInvalidSSLCertificate;
+@synthesize responseData = _responseData;
+@synthesize responseString = _responseString;
+@synthesize responseStringEncoding = _responseStringEncoding;
+@synthesize totalBytesRead = _totalBytesRead;
+@dynamic inputStream;
+@synthesize outputStream = _outputStream;
+@synthesize credential = _credential;
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+@synthesize SSLPinningMode = _SSLPinningMode;
+#endif
+@synthesize shouldUseCredentialStorage = _shouldUseCredentialStorage;
+@synthesize userInfo = _userInfo;
+@synthesize backgroundTaskIdentifier = _backgroundTaskIdentifier;
+@synthesize uploadProgress = _uploadProgress;
+@synthesize downloadProgress = _downloadProgress;
+@synthesize authenticationChallenge = _authenticationChallenge;
+#ifndef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+@synthesize authenticationAgainstProtectionSpace = _authenticationAgainstProtectionSpace;
+#endif
+@synthesize cacheResponse = _cacheResponse;
+@synthesize redirectResponse = _redirectResponse;
+@synthesize lock = _lock;
+
++ (void) __attribute__((noreturn)) networkRequestThreadEntryPoint:(id)__unused object {
+    do {
+        @autoreleasepool {
+            [[NSThread currentThread] setName:@"AFNetworking"];
+            [[NSRunLoop currentRunLoop] run];
+        }
+    } while (YES);
+}
+
++ (NSThread *)networkRequestThread {
+    static NSThread *_networkRequestThread = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _networkRequestThread = [[NSThread alloc] initWithTarget:self selector:@selector(networkRequestThreadEntryPoint:) object:nil];
+        [_networkRequestThread start];
+    });
+    
+    return _networkRequestThread;
+}
+
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
++ (NSArray *)pinnedCertificates {
+    static NSArray *_pinnedCertificates = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        NSArray *paths = [bundle pathsForResourcesOfType:@"cer" inDirectory:@"."];
+        
+        NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[paths count]];
+        for (NSString *path in paths) {
+            NSData *certificateData = [NSData dataWithContentsOfFile:path];
+            [certificates addObject:certificateData];
+        }
+        
+        _pinnedCertificates = [[NSArray alloc] initWithArray:certificates];
+    });
+    
+    return _pinnedCertificates;
+}
+
++ (NSArray *)pinnedPublicKeys {
+    static NSArray *_pinnedPublicKeys = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSArray *pinnedCertificates = [self pinnedCertificates];
+        NSMutableArray *publicKeys = [NSMutableArray arrayWithCapacity:[pinnedCertificates count]];
+        
+        for (NSData *data in pinnedCertificates) {
+            SecCertificateRef allowedCertificate = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)data);
+            NSParameterAssert(allowedCertificate);
+            
+            SecCertificateRef allowedCertificates[] = {allowedCertificate};
+            CFArrayRef certificates = CFArrayCreate(NULL, (const void **)allowedCertificates, 1, NULL);
+            
+            SecPolicyRef policy = SecPolicyCreateBasicX509();
+            SecTrustRef allowedTrust = NULL;
+            OSStatus status = SecTrustCreateWithCertificates(certificates, policy, &allowedTrust);
+            NSAssert(status == errSecSuccess, @"SecTrustCreateWithCertificates error: %ld", (long int)status);
+            
+            SecTrustResultType result = 0;
+            status = SecTrustEvaluate(allowedTrust, &result);
+            NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+            
+            SecKeyRef allowedPublicKey = SecTrustCopyPublicKey(allowedTrust);            
+            NSParameterAssert(allowedPublicKey);
+            [publicKeys addObject:(__bridge_transfer id)allowedPublicKey];
+            
+            CFRelease(allowedTrust);
+            CFRelease(policy);
+            CFRelease(certificates);
+            CFRelease(allowedCertificate);
+        }
+        
+        _pinnedPublicKeys = [[NSArray alloc] initWithArray:publicKeys];
+    });
+    
+    return _pinnedPublicKeys;
+}
+#endif
+
+- (id)initWithRequest:(NSURLRequest *)urlRequest {
+    NSParameterAssert(urlRequest);
+
+    self = [super init];
+    if (!self) {
+		return nil;
+    }
+    
+    self.lock = [[NSRecursiveLock alloc] init];
+    self.lock.name = kAFNetworkingLockName;
+    
+    self.runLoopModes = [NSSet setWithObject:NSRunLoopCommonModes];
+    
+    self.request = urlRequest;
+    
+    self.shouldUseCredentialStorage = YES;
+
+    // #ifdef included for backwards-compatibility 
+#ifdef _AFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
+    self.allowsInvalidSSLCertificate = YES;
+#endif
+
+    self.state = AFOperationReadyState;
+
+    return self;
+}
+
+- (void)dealloc {
+    if (_outputStream) {
+        [_outputStream close];
+        _outputStream = nil;
+    }
+    
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    if (_backgroundTaskIdentifier) {
+        [[UIApplication sharedApplication] endBackgroundTask:_backgroundTaskIdentifier];
+        _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    }
+#endif
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, state: %@, cancelled: %@ request: %@, response: %@>", NSStringFromClass([self class]), self, AFKeyPathFromOperationState(self.state), ([self isCancelled] ? @"YES" : @"NO"), self.request, self.response];
+}
+
+- (void)setCompletionBlock:(void (^)(void))block {
+    [self.lock lock];
+    if (!block) {
+        [super setCompletionBlock:nil];
+    } else {
+        __weak __typeof(&*self)weakSelf = self;
+        [super setCompletionBlock:^ {
+            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            
+            block();
+            [strongSelf setCompletionBlock:nil];
+        }];
+    }
+    [self.lock unlock];
+}
+
+- (NSInputStream *)inputStream {
+    return self.request.HTTPBodyStream;
+}
+
+- (void)setInputStream:(NSInputStream *)inputStream {
+    [self willChangeValueForKey:@"inputStream"];
+    NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+    mutableRequest.HTTPBodyStream = inputStream;
+    self.request = mutableRequest;
+    [self didChangeValueForKey:@"inputStream"];
+}
+
+- (NSOutputStream *)outputStream {
+    if (!_outputStream) {
+        self.outputStream = [NSOutputStream outputStreamToMemory];
+    }
+
+    return _outputStream;
+}
+
+- (void)setOutputStream:(NSOutputStream *)outputStream {
+    [self.lock lock];
+    if (outputStream != _outputStream) {
+        [self willChangeValueForKey:@"outputStream"];
+        if (_outputStream) {
+            [_outputStream close];
+        }
+        _outputStream = outputStream;
+        [self didChangeValueForKey:@"outputStream"];
+    }
+    [self.lock unlock];
+}
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
+    [self.lock lock];
+    if (!self.backgroundTaskIdentifier) {
+        UIApplication *application = [UIApplication sharedApplication];
+        __weak __typeof(&*self)weakSelf = self;
+        self.backgroundTaskIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
+            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            
+            if (handler) {
+                handler();
+            }
+            
+            if (strongSelf) {
+                [strongSelf cancel];
+                
+                [application endBackgroundTask:strongSelf.backgroundTaskIdentifier];
+                strongSelf.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
+    [self.lock unlock];
+}
+#endif
+
+- (void)setUploadProgressBlock:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))block {
+    self.uploadProgress = block;
+}
+
+- (void)setDownloadProgressBlock:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block {
+    self.downloadProgress = block;
+}
+
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block {
+    self.authenticationChallenge = block;
+}
+
+#else
+
+- (void)setAuthenticationAgainstProtectionSpaceBlock:(BOOL (^)(NSURLConnection *, NSURLProtectionSpace *))block {
+    self.authenticationAgainstProtectionSpace = block;
+}
+
+- (void)setAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block {
+    self.authenticationChallenge = block;
+}
+
+#endif
+
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block {
+    self.cacheResponse = block;
+}
+
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block {
+    self.redirectResponse = block;
+}
+
+- (void)setState:(AFOperationState)state {
+    if (!AFStateTransitionIsValid(self.state, state, [self isCancelled])) {
+        return;
+    }
+    
+    [self.lock lock];
+    NSString *oldStateKey = AFKeyPathFromOperationState(self.state);
+    NSString *newStateKey = AFKeyPathFromOperationState(state);
+    
+    [self willChangeValueForKey:newStateKey];
+    [self willChangeValueForKey:oldStateKey];
+    _state = state;
+    [self didChangeValueForKey:oldStateKey];
+    [self didChangeValueForKey:newStateKey];
+    [self.lock unlock];
+}
+
+- (NSString *)responseString {
+    [self.lock lock];
+    if (!_responseString && self.response && self.responseData) {
+        self.responseString = [[NSString alloc] initWithData:self.responseData encoding:self.responseStringEncoding];
+    }
+    [self.lock unlock];
+    
+    return _responseString;
+}
+
+- (NSStringEncoding)responseStringEncoding {
+    [self.lock lock];
+    if (!_responseStringEncoding && self.response) {
+        NSStringEncoding stringEncoding = NSUTF8StringEncoding;
+        if (self.response.textEncodingName) {
+            CFStringEncoding IANAEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)self.response.textEncodingName);
+            if (IANAEncoding != kCFStringEncodingInvalidId) {
+                stringEncoding = CFStringConvertEncodingToNSStringEncoding(IANAEncoding);
+            }
+        }
+        
+        self.responseStringEncoding = stringEncoding;
+    }
+    [self.lock unlock];
+    
+    return _responseStringEncoding;
+}
+
+- (void)pause {
+    if ([self isPaused] || [self isFinished] || [self isCancelled]) {
+        return;
+    }
+    
+    [self.lock lock];
+    
+    if ([self isExecuting]) {
+        [self.connection performSelector:@selector(cancel) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+            [notificationCenter postNotificationName:AFNetworkingOperationDidFinishNotification object:self];
+        });
+    }
+    
+    self.state = AFOperationPausedState;
+    
+    [self.lock unlock];
+}
+
+- (BOOL)isPaused {
+    return self.state == AFOperationPausedState;
+}
+
+- (void)resume {
+    if (![self isPaused]) {
+        return;
+    }
+    
+    [self.lock lock];
+    self.state = AFOperationReadyState;
+    
+    [self start];
+    [self.lock unlock];
+}
+
+#pragma mark - NSOperation
+
+- (BOOL)isReady {
+    return self.state == AFOperationReadyState && [super isReady];
+}
+
+- (BOOL)isExecuting {
+    return self.state == AFOperationExecutingState;
+}
+
+- (BOOL)isFinished {
+    return self.state == AFOperationFinishedState;
+}
+
+- (BOOL)isConcurrent {
+    return YES;
+}
+
+- (void)start {
+    [self.lock lock];
+    if ([self isReady]) {
+        self.state = AFOperationExecutingState;
+        
+        [self performSelector:@selector(operationDidStart) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+    }
+    [self.lock unlock];
+}
+
+- (void)operationDidStart {
+    [self.lock lock];
+    if (! [self isCancelled]) {
+        self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
+        
+        NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
+        for (NSString *runLoopMode in self.runLoopModes) {
+            [self.connection scheduleInRunLoop:runLoop forMode:runLoopMode];
+            [self.outputStream scheduleInRunLoop:runLoop forMode:runLoopMode];
+        }
+        
+        [self.connection start];
+    }
+    [self.lock unlock];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingOperationDidStartNotification object:self];
+    });
+    
+    if ([self isCancelled]) {
+        [self finish];
+    }
+}
+
+- (void)finish {
+    self.state = AFOperationFinishedState;
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:AFNetworkingOperationDidFinishNotification object:self];
+    });
+}
+
+- (void)cancel {
+    [self.lock lock];
+    if (![self isFinished] && ![self isCancelled]) {
+        [self willChangeValueForKey:@"isCancelled"];
+        _cancelled = YES;
+        [super cancel];
+        [self didChangeValueForKey:@"isCancelled"];
+        
+        // Cancel the connection on the thread it runs on to prevent race conditions
+        [self performSelector:@selector(cancelConnection) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+    }
+    [self.lock unlock];
+}
+
+- (void)cancelConnection {
+    NSDictionary *userInfo = nil;
+    if ([self.request URL]) {
+        userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+    }
+    self.error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
+    
+    if (self.connection) {
+        [self.connection cancel];
+        
+        // Manually send this delegate message since `[self.connection cancel]` causes the connection to never send another message to its delegate
+        [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.error];
+    }
+}
+
+#pragma mark - NSURLConnectionDelegate
+
+#ifdef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+
+- (void)connection:(NSURLConnection *)connection
+willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    if (self.authenticationChallenge) {
+        self.authenticationChallenge(connection, challenge);
+        return;
+    }
+    
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+        
+        SecPolicyRef policy = SecPolicyCreateBasicX509();
+        CFIndex certificateCount = SecTrustGetCertificateCount(serverTrust);
+        NSMutableArray *trustChain = [NSMutableArray arrayWithCapacity:certificateCount];
+        
+        for (CFIndex i = 0; i < certificateCount; i++) {
+            SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, i);
+            
+            if (self.SSLPinningMode == AFSSLPinningModeCertificate) {
+                [trustChain addObject:(__bridge_transfer NSData *)SecCertificateCopyData(certificate)];
+            } else if (self.SSLPinningMode == AFSSLPinningModePublicKey) {
+                SecCertificateRef someCertificates[] = {certificate};
+                CFArrayRef certificates = CFArrayCreate(NULL, (const void **)someCertificates, 1, NULL);
+                
+                SecTrustRef trust = NULL;
+                
+                OSStatus status = SecTrustCreateWithCertificates(certificates, policy, &trust);
+                NSAssert(status == errSecSuccess, @"SecTrustCreateWithCertificates error: %ld", (long int)status);
+                
+                SecTrustResultType result;
+                status = SecTrustEvaluate(trust, &result);
+                NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+                
+                [trustChain addObject:(__bridge_transfer id)SecTrustCopyPublicKey(trust)];
+                
+                CFRelease(trust);
+                CFRelease(certificates);
+            }
+        }
+        
+        CFRelease(policy);
+        
+        switch (self.SSLPinningMode) {
+            case AFSSLPinningModePublicKey: {
+                NSArray *pinnedPublicKeys = [self.class pinnedPublicKeys];
+                
+                for (id publicKey in trustChain) {
+                    for (id pinnedPublicKey in pinnedPublicKeys) {
+                        if (AFSecKeyIsEqualToKey((__bridge SecKeyRef)publicKey, (__bridge SecKeyRef)pinnedPublicKey)) {
+                            NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                            return;
+                        }
+                    }
+                }
+                
+                [[challenge sender] cancelAuthenticationChallenge:challenge];
+                break;
+            }
+            case AFSSLPinningModeCertificate: {
+                for (id serverCertificateData in trustChain) {
+                    if ([[self.class pinnedCertificates] containsObject:serverCertificateData]) {
+                        NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                        [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                        return;
+                    }
+                }
+                
+                [[challenge sender] cancelAuthenticationChallenge:challenge];
+                break;
+            }
+            case AFSSLPinningModeNone: {
+                if (self.allowsInvalidSSLCertificate){
+                    NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                    [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                } else {
+                    SecTrustResultType result = 0;
+                    OSStatus status = SecTrustEvaluate(serverTrust, &result);
+                    NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+                    
+                    if (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed) {
+                        NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                        [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                    } else {
+                        [[challenge sender] cancelAuthenticationChallenge:challenge];
+                    }
+                }
+                break;
+            }
+        }
+    } else {
+        if ([challenge previousFailureCount] == 0) {
+            if (self.credential) {
+                [[challenge sender] useCredential:self.credential forAuthenticationChallenge:challenge];
+            } else {
+                [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+            }
+        } else {
+            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+        }
+    }
+}
+
+#else
+
+- (BOOL)connection:(NSURLConnection *)connection
+canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
+{
+    if (self.allowsInvalidSSLCertificate &&
+       [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+            return YES;
+    }
+    
+    if (self.authenticationAgainstProtectionSpace) {
+        return self.authenticationAgainstProtectionSpace(connection, protectionSpace);
+    } else if ([protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust] || [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate]) {
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
+- (void)connection:(NSURLConnection *)connection
+didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+
+    if (self.allowsInvalidSSLCertificate
+       && [challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        [challenge.sender useCredential:[NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust] forAuthenticationChallenge:challenge];
+        return;
+    }
+
+    if (self.authenticationChallenge) {
+        self.authenticationChallenge(connection, challenge);
+    } else {
+        if ([challenge previousFailureCount] == 0) {
+            if (self.credential) {
+                [[challenge sender] useCredential:self.credential forAuthenticationChallenge:challenge];
+            } else {
+                [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+            }
+        } else {
+            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+        }
+    }
+}
+
+#endif
+
+- (BOOL)connectionShouldUseCredentialStorage:(NSURLConnection __unused *)connection {
+    return self.shouldUseCredentialStorage;
+}
+
+- (NSInputStream *)connection:(NSURLConnection __unused *)connection
+            needNewBodyStream:(NSURLRequest *)request
+{
+    if ([request.HTTPBodyStream conformsToProtocol:@protocol(NSCopying)]) {
+        return [request.HTTPBodyStream copy];
+    } else {
+        [self cancelConnection];
+        
+        return nil;
+    }
+}
+
+- (NSURLRequest *)connection:(NSURLConnection *)connection
+             willSendRequest:(NSURLRequest *)request
+            redirectResponse:(NSURLResponse *)redirectResponse
+{
+    if (self.redirectResponse) {
+        return self.redirectResponse(connection, request, redirectResponse);
+    } else {
+        return request;
+    }
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+   didSendBodyData:(NSInteger)bytesWritten
+ totalBytesWritten:(NSInteger)totalBytesWritten
+totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
+{
+    if (self.uploadProgress) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.uploadProgress((NSUInteger)bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
+        });
+    }
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+didReceiveResponse:(NSURLResponse *)response
+{
+    self.response = response;
+    
+    [self.outputStream open];
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+    didReceiveData:(NSData *)data
+{
+    NSUInteger length = [data length];
+    if ([self.outputStream hasSpaceAvailable]) {
+        const uint8_t *dataBuffer = (uint8_t *) [data bytes];
+        [self.outputStream write:&dataBuffer[0] maxLength:length];
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.totalBytesRead += length;
+        
+        if (self.downloadProgress) {
+            self.downloadProgress(length, self.totalBytesRead, self.response.expectedContentLength);
+        }
+    });
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection __unused *)connection {
+    self.responseData = [self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+    
+    [self.outputStream close];
+    
+    [self finish];
+    
+    self.connection = nil;
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+  didFailWithError:(NSError *)error
+{
+    self.error = error;
+    
+    [self.outputStream close];
+    
+    [self finish];
+    
+    self.connection = nil;
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection
+                  willCacheResponse:(NSCachedURLResponse *)cachedResponse
+{
+    if (self.cacheResponse) {
+        return self.cacheResponse(connection, cachedResponse);
+    } else {
+        if ([self isCancelled]) {
+            return nil;
+        }
+        
+        return cachedResponse;
+    }
+}
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    NSURLRequest *request = [aDecoder decodeObjectForKey:@"request"];
+    
+    self = [self initWithRequest:request];
+    if (!self) {
+        return nil;
+    }
+    
+    self.state = (AFOperationState)[aDecoder decodeIntegerForKey:@"state"];
+    self.cancelled = [aDecoder decodeBoolForKey:@"isCancelled"];
+    self.response = [aDecoder decodeObjectForKey:@"response"];
+    self.error = [aDecoder decodeObjectForKey:@"error"];
+    self.responseData = [aDecoder decodeObjectForKey:@"responseData"];
+    self.totalBytesRead = [[aDecoder decodeObjectForKey:@"totalBytesRead"] longLongValue];
+    self.allowsInvalidSSLCertificate = [[aDecoder decodeObjectForKey:@"allowsInvalidSSLCertificate"] boolValue];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [self pause];
+    
+    [aCoder encodeObject:self.request forKey:@"request"];
+    
+    switch (self.state) {
+        case AFOperationExecutingState:
+        case AFOperationPausedState:
+            [aCoder encodeInteger:AFOperationReadyState forKey:@"state"];
+            break;
+        default:
+            [aCoder encodeInteger:self.state forKey:@"state"];
+            break;
+    }
+    
+    [aCoder encodeBool:[self isCancelled] forKey:@"isCancelled"];
+    [aCoder encodeObject:self.response forKey:@"response"];
+    [aCoder encodeObject:self.error forKey:@"error"];
+    [aCoder encodeObject:self.responseData forKey:@"responseData"];
+    [aCoder encodeObject:[NSNumber numberWithLongLong:self.totalBytesRead] forKey:@"totalBytesRead"];
+    [aCoder encodeObject:[NSNumber numberWithBool:self.allowsInvalidSSLCertificate] forKey:@"allowsInvalidSSLCertificate"];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    ZincURLConnectionOperation *operation = [(ZincURLConnectionOperation *)[[self class] allocWithZone:zone] initWithRequest:self.request];
+    
+    operation.uploadProgress = self.uploadProgress;
+    operation.downloadProgress = self.downloadProgress;
+#ifndef _AFNETWORKING_PIN_SSL_CERTIFICATES_
+    operation.authenticationAgainstProtectionSpace = self.authenticationAgainstProtectionSpace;
+#endif
+    operation.authenticationChallenge = self.authenticationChallenge;
+    operation.cacheResponse = self.cacheResponse;
+    operation.redirectResponse = self.redirectResponse;
+    operation.allowsInvalidSSLCertificate = self.allowsInvalidSSLCertificate;
+    
+    return operation;
+}
+
+@end


### PR DESCRIPTION
This is in anticipation of NSURLSession. I think Zinc should just manage it's own HTTP stuff and not rely on 3rd party libs.
