### PR TITLE
Safer file move

### DIFF
--- a/Zinc/NSFileManager+Zinc.h
+++ b/Zinc/NSFileManager+Zinc.h
@@ -18,4 +18,18 @@
 
 - (BOOL) zinc_removeItemAtPath:(NSString*)path error:(NSError**)outError;
 
+/**
+ Convenience method for moving files.
+ @param srcPath the source path
+ @param dstPath the destination path
+ @param failIfExists If YES, raise an error if the dstPath exists, if NO proceed without an error.
+ @param error output params
+ */
+- (BOOL) zinc_moveItemAtPath:(NSString*)srcPath toPath:(NSString*)dstPath failIfExists:(BOOL)failIfExists error:(NSError**)error;
+
+/**
+ Like zinc_moveItemAtPath:toPath:failIfExists:error but failIfExists is NO
+ */
+- (BOOL) zinc_moveItemAtPath:(NSString*)srcPath toPath:(NSString*)dstPath error:(NSError**)error;
+
 @end

--- a/Zinc/NSFileManager+Zinc.m
+++ b/Zinc/NSFileManager+Zinc.m
@@ -50,5 +50,28 @@
     return YES;
 }
 
+- (BOOL) zinc_moveItemAtPath:(NSString*)srcPath toPath:(NSString*)dstPath failIfExists:(BOOL)failIfExists error:(NSError**)error
+{
+    NSError* myError = nil;
+    BOOL success = [self moveItemAtPath:srcPath toPath:dstPath error:&myError];
+    if (!success &&
+        !failIfExists &&
+        [myError.domain isEqualToString:NSCocoaErrorDomain] &&
+        myError.code == NSFileWriteFileExistsError)
+    {
+        return YES;
+    }
+
+    if (error != NULL) {
+        *error = myError;
+    }
+
+    return success;
+}
+
+- (BOOL) zinc_moveItemAtPath:(NSString*)srcPath toPath:(NSString*)dstPath error:(NSError**)error
+{
+    return [self zinc_moveItemAtPath:srcPath toPath:dstPath failIfExists:NO error:error];
+}
 
 @end

--- a/Zinc/NSFileManager+Zinc.m
+++ b/Zinc/NSFileManager+Zinc.m
@@ -59,7 +59,8 @@
         [myError.domain isEqualToString:NSCocoaErrorDomain] &&
         myError.code == NSFileWriteFileExistsError)
     {
-        return YES;
+        success = YES;
+        myError = nil;
     }
 
     if (error != NULL) {

--- a/Zinc/ZincArchiveExtractOperation.m
+++ b/Zinc/ZincArchiveExtractOperation.m
@@ -107,7 +107,7 @@
 
         } else {
         
-            if (![fm moveItemAtPath:fullPath toPath:targetPath error:&error]) {
+            if (![fm zinc_moveItemAtPath:fullPath toPath:targetPath error:&error]) {
                 self.error = error;
                 cleanup();
                 return;

--- a/Zinc/ZincObjectDownloadTask.m
+++ b/Zinc/ZincObjectDownloadTask.m
@@ -144,14 +144,11 @@
                 continue;
             }
 
-            if (![fm moveItemAtPath:uncompressedPath toPath:targetPath error:&error]) {
-                if (error.code != NSFileWriteFileExistsError) // ignore error if file already existed
-                {
-                    [self addEvent:[ZincErrorEvent eventWithError:error source:ZINC_EVENT_SRC()]];
-                    continue;
-                }
+            if (![fm zinc_moveItemAtPath:uncompressedPath toPath:targetPath error:&error]) {
+                [self addEvent:[ZincErrorEvent eventWithError:error source:ZINC_EVENT_SRC()]];
+                continue;
             }
-            
+
             ZincAddSkipBackupAttributeToFileWithPath(targetPath);
             self.finishedSuccessfully = YES;
         }

--- a/ZincTests/ZincFileManagerTest.m
+++ b/ZincTests/ZincFileManagerTest.m
@@ -8,6 +8,7 @@
 
 #import "ZincFileManagerTest.h"
 #import "ZincSHA.h"
+#import "NSFileManager+Zinc.h"
 
 @implementation ZincFileManagerTest
 
@@ -21,6 +22,114 @@
     STAssertNotNil(sha, @"sha is nil");
     STAssertEqualObjects(sha, @"f0d25f7505e777633104888e88c68e9b9655f62f", @"sha is wrong");
 }
+
+- (void)testMoveItemAtPath_DstDoesNotExist_FailIfExists
+{
+    NSError* error = nil;
+
+    NSString* src = TEST_TMP_PATH(@"src", @"txt");
+    if (![@"pineapple" writeToFile:src atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSString* dst = TEST_TMP_PATH(@"dst", @"txt");
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    BOOL srcExists = [fm fileExistsAtPath:src];
+    BOOL dstExists = [fm fileExistsAtPath:dst];
+
+    STAssertTrue(srcExists, @"src should exist");
+    STAssertFalse(dstExists, @"dst should no exist");
+
+    BOOL moveSuccess = [fm zinc_moveItemAtPath:src toPath:dst failIfExists:YES error:&error];
+    STAssertTrue(moveSuccess, @"should succeed: %@", error);
+
+    [fm removeItemAtPath:src error:NULL];
+    [fm removeItemAtPath:dst error:NULL];
+}
+
+- (void)testMoveItemAtPath_DstDoesExist_FailIfExists
+{
+    NSError* error = nil;
+
+    NSString* src = TEST_TMP_PATH(@"src", @"txt");
+    if (![@"pineapple" writeToFile:src atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSString* dst = TEST_TMP_PATH(@"dst", @"txt");
+    if (![@"grapefruit" writeToFile:dst atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    BOOL srcExists = [fm fileExistsAtPath:src];
+    BOOL dstExists = [fm fileExistsAtPath:dst];
+
+    STAssertTrue(srcExists, @"src should exist");
+    STAssertTrue(dstExists, @"dst should no exist");
+
+    BOOL moveSuccess = [fm zinc_moveItemAtPath:src toPath:dst failIfExists:YES error:&error];
+    STAssertFalse(moveSuccess, @"should succeed: %@", error);
+
+    [fm removeItemAtPath:src error:NULL];
+    [fm removeItemAtPath:dst error:NULL];
+}
+
+- (void)testMoveItemAtPath_DstDoesNotExist_NotFailIfExists
+{
+    NSError* error = nil;
+
+    NSString* src = TEST_TMP_PATH(@"src", @"txt");
+    if (![@"pineapple" writeToFile:src atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSString* dst = TEST_TMP_PATH(@"dst", @"txt");
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    BOOL srcExists = [fm fileExistsAtPath:src];
+    BOOL dstExists = [fm fileExistsAtPath:dst];
+
+    STAssertTrue(srcExists, @"src should exist");
+    STAssertFalse(dstExists, @"dst should no exist");
+
+    BOOL moveSuccess = [fm zinc_moveItemAtPath:src toPath:dst failIfExists:NO error:&error];
+    STAssertTrue(moveSuccess, @"should succeed: %@", error);
+
+    [fm removeItemAtPath:src error:NULL];
+    [fm removeItemAtPath:dst error:NULL];
+}
+
+- (void)testMoveItemAtPath_DstDoesExist_NotFailIfExists
+{
+    NSError* error = nil;
+
+    NSString* src = TEST_TMP_PATH(@"src", @"txt");
+    if (![@"pineapple" writeToFile:src atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSString* dst = TEST_TMP_PATH(@"dst", @"txt");
+    if (![@"grapefruit" writeToFile:dst atomically:NO encoding:NSUTF8StringEncoding error:&error]) {
+        STFail(@"error: %@", error);
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    BOOL srcExists = [fm fileExistsAtPath:src];
+    BOOL dstExists = [fm fileExistsAtPath:dst];
+
+    STAssertTrue(srcExists, @"src should exist");
+    STAssertTrue(dstExists, @"dst should no exist");
+
+    BOOL moveSuccess = [fm zinc_moveItemAtPath:src toPath:dst failIfExists:NO error:&error];
+    STAssertTrue(moveSuccess, @"should succeed: %@", error);
+
+    [fm removeItemAtPath:src error:NULL];
+    [fm removeItemAtPath:dst error:NULL];
+}
+
+
 
 
 @end


### PR DESCRIPTION
Zinc was only handling the error if the destination already existed during a file move in 1 place, but it was moving files in 2.

This unifies the file move error handling logic and adds tests.
