### PR TITLE
Allow for sync logging

### DIFF
--- a/Zinc/Private/ZincRepo.m
+++ b/Zinc/Private/ZincRepo.m
@@ -1301,12 +1301,8 @@ ifSumOfSizeHasReachedLimitInMegabytes:(float)sizeLimitInMB {
         [self.eventListener zincRepo:self didReceiveEvent:event];
     }
 
-    __weak typeof(self) weakself = self;
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        __strong typeof(weakself) strongself = weakself;
-        NSMutableDictionary* userInfo = [event.attributes mutableCopy];
-        [[NSNotificationCenter defaultCenter] postNotificationName:[[event class] notificationName] object:self userInfo:userInfo];
-    }];
+    NSMutableDictionary* userInfo = [event.attributes mutableCopy];
+    [self postNotification:[[event class] notificationName] userInfo:userInfo];
 }
 
 + (void)setDefaultThreadPriority:(double)defaultThreadPriority

--- a/Zinc/Private/ZincRepo.m
+++ b/Zinc/Private/ZincRepo.m
@@ -1297,12 +1297,13 @@ ifSumOfSizeHasReachedLimitInMegabytes:(float)sizeLimitInMB {
 
 - (void) logEvent:(ZincEvent*)event
 {
+    if ([self.eventListener respondsToSelector:@selector(zincRepo:didReceiveEvent:)]) {
+        [self.eventListener zincRepo:self didReceiveEvent:event];
+    }
+
     __weak typeof(self) weakself = self;
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         __strong typeof(weakself) strongself = weakself;
-        if ([strongself.eventListener respondsToSelector:@selector(zincRepo:didReceiveEvent:)])
-            [strongself.eventListener zincRepo:strongself didReceiveEvent:event];
-        
         NSMutableDictionary* userInfo = [event.attributes mutableCopy];
         [[NSNotificationCenter defaultCenter] postNotificationName:[[event class] notificationName] object:self userInfo:userInfo];
     }];

--- a/Zinc/Public/ZincRepo.h
+++ b/Zinc/Public/ZincRepo.h
@@ -362,6 +362,8 @@ extern NSString* const ZincRepoTaskNotificationTaskKey;
 
 /**
  Called whenever an event occurs in the ZincRepo
+
+ May be called on a background queue
  
  @param repo The repo
  @param event The event


### PR DESCRIPTION
In order to best track the missing bundle crash, allowing for sync logging will help make sure all logs are up to date when the crash occurs.